### PR TITLE
Refactor JSON deserialization to direct-stream reading with optimizations

### DIFF
--- a/src/LHZ.FastJson.Benchmark/DeserializationBenchmarks.cs
+++ b/src/LHZ.FastJson.Benchmark/DeserializationBenchmarks.cs
@@ -22,15 +22,15 @@ namespace LHZ.FastJson.Benchmark
         [GlobalSetup]
         public void Setup()
         {
-            // 使用 LHZ.FastJson 生成 JSON 字符串作为反序列化输入
-            _smallModelJson = JsonConvert.Serialize(BenchmarkData.CreateSmallModel());
-            _mediumModelJson = JsonConvert.Serialize(BenchmarkData.CreateMediumModel());
-            _largeListJson = JsonConvert.Serialize(BenchmarkData.CreateLargeList());
-            _dictionaryJson = JsonConvert.Serialize(BenchmarkData.CreateDictionary());
-            _stringWithEscapesJson = JsonConvert.Serialize(BenchmarkData.CreateStringWithEscapes());
-            _nullableWithValuesJson = JsonConvert.Serialize(BenchmarkData.CreateNullableModel_WithValues());
-            _nullableWithNullsJson = JsonConvert.Serialize(BenchmarkData.CreateNullableModel_WithNulls());
-            _enumModelJson = JsonConvert.Serialize(BenchmarkData.CreateEnumModel());
+            // 使用 Newtonsoft.Json 生成 JSON（ISO 8601 DateTime 格式），确保三个库都能解析
+            _smallModelJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateSmallModel());
+            _mediumModelJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateMediumModel());
+            _largeListJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateLargeList());
+            _dictionaryJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateDictionary());
+            _stringWithEscapesJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateStringWithEscapes());
+            _nullableWithValuesJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateNullableModel_WithValues());
+            _nullableWithNullsJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateNullableModel_WithNulls());
+            _enumModelJson = Newtonsoft.Json.JsonConvert.SerializeObject(BenchmarkData.CreateEnumModel());
         }
 
         // ──────────────── LHZ.FastJson ────────────────

--- a/src/LHZ.FastJson.Benchmark/LHZ.FastJson.Benchmark.csproj
+++ b/src/LHZ.FastJson.Benchmark/LHZ.FastJson.Benchmark.csproj
@@ -2,15 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <NoWarn>$(NoWarn);NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LHZ.FastJson.UnitTest/LHZ.FastJson.UnitTest.csproj
+++ b/src/LHZ.FastJson.UnitTest/LHZ.FastJson.UnitTest.csproj
@@ -1,19 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>NET10.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="nunit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\LHZ.FastJson\LHZ.FastJson.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/LHZ.FastJson.UnitTest/RegressionTests.cs
+++ b/src/LHZ.FastJson.UnitTest/RegressionTests.cs
@@ -164,15 +164,7 @@ namespace LHZ.FastJson.UnitTest
         {
             var list = new ArrayList();
             list.Add(list);
-            try
-            {
-                var ret = JsonConvert.Serialize(list);
-            }
-            catch(Exception)
-            {
-                Assert.Pass();
-            }
-            Assert.Fail();
+            Assert.Throws<InvalidOperationException>(()=>JsonConvert.Serialize(list));
         }
 
         /// <summary>
@@ -268,7 +260,7 @@ namespace LHZ.FastJson.UnitTest
         [Test]
         public void DeserializeTypeMismatchThrowsException()
         {
-            Assert.Throws<JsonDeserializationException>(() => JsonConvert.Deserialize<int>("\"not a number\""));
+            Assert.Throws<JsonDirectDeserializationException>(() => JsonConvert.Deserialize<int>("\"not a number\""));
         }
 
         /// <summary>

--- a/src/LHZ.FastJson.UnitTest/TestJsonDeserizlizer.cs
+++ b/src/LHZ.FastJson.UnitTest/TestJsonDeserizlizer.cs
@@ -476,7 +476,6 @@ namespace LHZ.FastJson.UnitTest
         {
             var jsonStr = "{\"Id\":1, \"Name\":\"tom\"}";
             var obj = JsonConvert.Deserialize<TestObjClass>(jsonStr, new JsonCustomConvert<int>(n=> 2));
-           
             Assert.AreEqual(obj.Id, 2);
         }
 

--- a/src/LHZ.FastJson.UnitTest/TestJsonDirectReader.cs
+++ b/src/LHZ.FastJson.UnitTest/TestJsonDirectReader.cs
@@ -1,0 +1,899 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using LHZ.FastJson.Enum;
+using LHZ.FastJson.Exceptions;
+using LHZ.FastJson.JsonClass;
+using LHZ.FastJson.Utils;
+using NUnit.Framework;
+
+namespace LHZ.FastJson.UnitTest;
+
+/// <summary>
+/// Comprehensive tests for the JsonDirectReader class.
+/// JsonDirectReader is internal, so reflection is used to access it.
+/// </summary>
+[TestFixture]
+public class TestJsonDirectReader
+{
+    #region Reflection Helpers
+
+    private static readonly Type ReaderType;
+    private static readonly ConstructorInfo CtorWithString;
+
+    static TestJsonDirectReader()
+    {
+        var assembly = Assembly.GetAssembly(typeof(JsonConvert));
+        ReaderType = assembly.GetType("LHZ.FastJson.JsonDirectReader");
+        CtorWithString = ReaderType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            null, new[] { typeof(string) }, null);
+    }
+
+    private const BindingFlags MethodFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+    /// <summary>Create a JsonDirectReader instance via reflection.</summary>
+    private static object CreateReader(string json)
+    {
+        return CtorWithString.Invoke(new object[] { json });
+    }
+
+    /// <summary>Get a property value from the reader.</summary>
+    private static T GetProp<T>(object reader, string name)
+    {
+        return (T)ReaderType.GetProperty(name, MethodFlags).GetValue(reader);
+    }
+
+    /// <summary>Invoke a method on the reader.</summary>
+    private static T Invoke<T>(object reader, string name, params object[] args)
+    {
+        return (T)ReaderType.GetMethod(name, MethodFlags).Invoke(reader, args);
+    }
+
+    /// <summary>Invoke a void method on the reader.</summary>
+    private static void InvokeVoid(object reader, string name, params object[] args)
+    {
+        ReaderType.GetMethod(name, MethodFlags).Invoke(reader, args);
+    }
+
+    /// <summary>Invoke a generic method on the reader.</summary>
+    private static T InvokeGeneric<T>(object reader, string name, Type[] typeArgs, params object[] args)
+    {
+        var method = ReaderType.GetMethod(name, MethodFlags);
+        var generic = method.MakeGenericMethod(typeArgs);
+        return (T)generic.Invoke(reader, args);
+    }
+
+    #endregion
+
+    #region Constructor & Basic Properties
+
+    /// <summary>
+    /// Verify that the constructor correctly sets Content, Position, and Length.
+    /// </summary>
+    [Test]
+    public void Constructor_SetsContentAndPosition()
+    {
+        var reader = CreateReader("{\"a\":1}");
+
+        Assert.AreEqual("{\"a\":1}", GetProp<string>(reader, "Content"));
+        Assert.AreEqual(0, GetProp<int>(reader, "Position"));
+        Assert.AreEqual(7, GetProp<int>(reader, "Length"));
+        Assert.IsFalse(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify that a null string argument throws ArgumentNullException.
+    /// </summary>
+    [Test]
+    public void Constructor_NullContent_ThrowsArgumentNullException()
+    {
+        Assert.Throws<TargetInvocationException>(() => CtorWithString.Invoke(new object[] { null }));
+    }
+
+    /// <summary>
+    /// Verify IsReadEnd returns true when Position reaches Length.
+    /// </summary>
+    [Test]
+    public void IsReadEnd_ReturnsTrue_WhenPositionReachesLength()
+    {
+        var reader = CreateReader("1");
+        Invoke<char>(reader, "Read"); // advance past '1'
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify CurrentChar returns the character at the current Position.
+    /// </summary>
+    [Test]
+    public void CurrentChar_ReturnsCharAtPosition()
+    {
+        var reader = CreateReader("abc");
+        Assert.AreEqual('a', GetProp<char>(reader, "CurrentChar"));
+        Invoke<char>(reader, "Read");
+        Assert.AreEqual('b', GetProp<char>(reader, "CurrentChar"));
+    }
+
+    #endregion
+
+    #region JsonType Detection
+
+    /// <summary>
+    /// Verify JsonType detects all six JSON types correctly.
+    /// </summary>
+    [Test]
+    public void JsonType_DetectsAllTypes()
+    {
+        Assert.AreEqual(JsonType.Content, GetProp<JsonType>(CreateReader("{}"), "JsonType"));
+        Assert.AreEqual(JsonType.Array, GetProp<JsonType>(CreateReader("[]"), "JsonType"));
+        Assert.AreEqual(JsonType.String, GetProp<JsonType>(CreateReader("\"hello\""), "JsonType"));
+        Assert.AreEqual(JsonType.Number, GetProp<JsonType>(CreateReader("42"), "JsonType"));
+        Assert.AreEqual(JsonType.Number, GetProp<JsonType>(CreateReader("-7"), "JsonType"));
+        Assert.AreEqual(JsonType.Boolean, GetProp<JsonType>(CreateReader("true"), "JsonType"));
+        Assert.AreEqual(JsonType.Boolean, GetProp<JsonType>(CreateReader("false"), "JsonType"));
+        Assert.AreEqual(JsonType.Null, GetProp<JsonType>(CreateReader("null"), "JsonType"));
+    }
+
+    /// <summary>
+    /// Verify JsonType skips leading whitespace before detecting type.
+    /// </summary>
+    [Test]
+    public void JsonType_SkipsLeadingWhitespace()
+    {
+        Assert.AreEqual(JsonType.String, GetProp<JsonType>(CreateReader("  \t\r\n\"x\""), "JsonType"));
+        Assert.AreEqual(JsonType.Number, GetProp<JsonType>(CreateReader("  123"), "JsonType"));
+        Assert.AreEqual(JsonType.Content, GetProp<JsonType>(CreateReader("  {}"), "JsonType"));
+    }
+
+    #endregion
+
+    #region Read & MoveNext
+
+    /// <summary>
+    /// Verify Read() advances Position and returns the character.
+    /// </summary>
+    [Test]
+    public void Read_AdvancesPositionAndReturnsChar()
+    {
+        var reader = CreateReader("xyz");
+        Assert.AreEqual('x', Invoke<char>(reader, "Read"));
+        Assert.AreEqual(1, GetProp<int>(reader, "Position"));
+        Assert.AreEqual('y', Invoke<char>(reader, "Read"));
+        Assert.AreEqual(2, GetProp<int>(reader, "Position"));
+    }
+
+    #endregion
+
+    #region SkipWhitespace
+
+    /// <summary>
+    /// Verify SkipWhitespace moves past spaces, tabs, newlines, and carriage returns.
+    /// </summary>
+    [Test]
+    public void SkipWhitespace_SkipsAllWhitespace()
+    {
+        var reader = CreateReader(" \t\r\n  {\"a\":1}");
+        InvokeVoid(reader, "SkipWhitespace");
+        Assert.AreEqual('{', GetProp<char>(reader, "CurrentChar"));
+        // " \t\r\n  " = 6 whitespace chars before '{'
+        Assert.AreEqual(6, GetProp<int>(reader, "Position"));
+    }
+
+    /// <summary>
+    /// Verify SkipWhitespace does nothing when already at end.
+    /// </summary>
+    [Test]
+    public void SkipWhitespace_DoesNothingAtEnd()
+    {
+        var reader = CreateReader(" ");
+        // The reader starts at position 0, SkipWhitespace should skip the whitespace
+        // but not throw at end (it returns when Position >= Length)
+        InvokeVoid(reader, "SkipWhitespace");
+        Assert.DoesNotThrow(() => InvokeVoid(reader, "SkipWhitespace"));
+    }
+
+    #endregion
+
+    #region ReadString
+
+    /// <summary>
+    /// Verify ReadString returns the string content without quotes.
+    /// </summary>
+    [Test]
+    public void ReadString_ReturnsStringContent()
+    {
+        var reader = CreateReader("\"Hello World\"");
+        Assert.AreEqual("Hello World", Invoke<string>(reader, "ReadString"));
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify ReadString handles empty strings.
+    /// </summary>
+    [Test]
+    public void ReadString_EmptyString()
+    {
+        var reader = CreateReader("\"\"");
+        Assert.AreEqual("", Invoke<string>(reader, "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify ReadString handles escape sequences.
+    /// </summary>
+    [Test]
+    public void ReadString_EscapeSequences()
+    {
+        Assert.AreEqual("quote\"here", Invoke<string>(CreateReader("\"quote\\\"here\""), "ReadString"));
+        Assert.AreEqual("back\\slash", Invoke<string>(CreateReader("\"back\\\\slash\""), "ReadString"));
+        Assert.AreEqual("line1\nline2", Invoke<string>(CreateReader("\"line1\\nline2\""), "ReadString"));
+        Assert.AreEqual("tab\there", Invoke<string>(CreateReader("\"tab\\there\""), "ReadString"));
+        Assert.AreEqual("carriage\rreturn", Invoke<string>(CreateReader("\"carriage\\rreturn\""), "ReadString"));
+        Assert.AreEqual("slash/path", Invoke<string>(CreateReader("\"slash\\/path\""), "ReadString"));
+        Assert.AreEqual("back\bspace", Invoke<string>(CreateReader("\"back\\bspace\""), "ReadString"));
+        Assert.AreEqual("form\ffeed", Invoke<string>(CreateReader("\"form\\ffeed\""), "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify ReadString handles unicode escape sequences.
+    /// </summary>
+    [Test]
+    public void ReadString_UnicodeEscapes()
+    {
+        Assert.AreEqual("ABC", Invoke<string>(CreateReader("\"\\u0041\\u0042\\u0043\""), "ReadString"));
+        Assert.AreEqual("中文", Invoke<string>(CreateReader("\"\\u4e2d\\u6587\""), "ReadString"));
+        Assert.AreEqual("\u00e9", Invoke<string>(CreateReader("\"\\u00e9\""), "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify ReadString handles mixed content with escapes.
+    /// </summary>
+    [Test]
+    public void ReadString_MixedContentWithEscapes()
+    {
+        var reader = CreateReader("\"hello\\nworld\\t!\"");
+        Assert.AreEqual("hello\nworld\t!", Invoke<string>(reader, "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify ReadString throws when the string is not properly quoted.
+    /// </summary>
+    [Test]
+    public void ReadString_NotQuoted_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("not_a_string");
+        Assert.Throws<TargetInvocationException>(() => Invoke<string>(reader, "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify ReadString throws for unclosed strings.
+    /// </summary>
+    [Test]
+    public void ReadString_Unclosed_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("\"unclosed");
+        Assert.Throws<TargetInvocationException>(() => Invoke<string>(reader, "ReadString"));
+    }
+
+    #endregion
+
+    #region ReadNumber (internal)
+
+    /// <summary>
+    /// Verify ReadNumber parses an integer correctly.
+    /// </summary>
+    [Test]
+    public void ReadNumber_Integer()
+    {
+        var reader = CreateReader("12345");
+        var sv = Invoke<object>(reader, "ReadNumber");
+        Assert.AreEqual("12345", sv.ToString());
+    }
+
+    /// <summary>
+    /// Verify ReadNumber parses a negative integer.
+    /// </summary>
+    [Test]
+    public void ReadNumber_NegativeInteger()
+    {
+        var reader = CreateReader("-42");
+        var sv = Invoke<object>(reader, "ReadNumber");
+        Assert.AreEqual("-42", sv.ToString());
+    }
+
+    /// <summary>
+    /// Verify ReadNumber parses a floating-point number.
+    /// </summary>
+    [Test]
+    public void ReadNumber_Float()
+    {
+        var reader = CreateReader("3.14159");
+        var sv = Invoke<object>(reader, "ReadNumber");
+        Assert.AreEqual("3.14159", sv.ToString());
+    }
+
+    /// <summary>
+    /// Verify ReadNumber parses scientific notation.
+    /// </summary>
+    [Test]
+    public void ReadNumber_ScientificNotation()
+    {
+        Assert.AreEqual("1e10", Invoke<object>(CreateReader("1e10"), "ReadNumber").ToString());
+        Assert.AreEqual("2.5E-3", Invoke<object>(CreateReader("2.5E-3"), "ReadNumber").ToString());
+        Assert.AreEqual("-1.5e+2", Invoke<object>(CreateReader("-1.5e+2"), "ReadNumber").ToString());
+        Assert.AreEqual("0.5e10", Invoke<object>(CreateReader("0.5e10"), "ReadNumber").ToString());
+    }
+
+    /// <summary>
+    /// Verify ReadNumber parses zero correctly.
+    /// </summary>
+    [Test]
+    public void ReadNumber_Zero()
+    {
+        var reader = CreateReader("0");
+        var sv = Invoke<object>(reader, "ReadNumber");
+        Assert.AreEqual("0", sv.ToString());
+    }
+
+    /// <summary>
+    /// Verify ReadNumber throws on leading zeros.
+    /// </summary>
+    [Test]
+    public void ReadNumber_LeadingZero_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("007");
+        Assert.Throws<TargetInvocationException>(() => Invoke<object>(reader, "ReadNumber"));
+    }
+
+    /// <summary>
+    /// Verify ReadNumber throws when sign is not followed by a digit.
+    /// </summary>
+    [Test]
+    public void ReadNumber_SignWithoutDigit_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("-");
+        Assert.Throws<TargetInvocationException>(() => Invoke<object>(reader, "ReadNumber"));
+    }
+
+    /// <summary>
+    /// Verify ReadNumber throws when decimal point is not followed by a digit.
+    /// </summary>
+    [Test]
+    public void ReadNumber_DecimalWithoutDigit_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("1.");
+        Assert.Throws<TargetInvocationException>(() => Invoke<object>(reader, "ReadNumber"));
+    }
+
+    #endregion
+
+    #region ReadBoolean (internal)
+
+    /// <summary>
+    /// Verify ReadBoolean returns true for "true".
+    /// </summary>
+    [Test]
+    public void ReadBoolean_True()
+    {
+        var reader = CreateReader("true");
+        Assert.IsTrue(Invoke<bool>(reader, "ReadBoolean"));
+    }
+
+    /// <summary>
+    /// Verify ReadBoolean returns false for "false".
+    /// </summary>
+    [Test]
+    public void ReadBoolean_False()
+    {
+        var reader = CreateReader("false");
+        Assert.IsFalse(Invoke<bool>(reader, "ReadBoolean"));
+    }
+
+    /// <summary>
+    /// Verify ReadBoolean throws for invalid boolean literals.
+    /// </summary>
+    [Test]
+    public void ReadBoolean_Invalid_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("tru");
+        Assert.Throws<TargetInvocationException>(() => Invoke<bool>(reader, "ReadBoolean"));
+    }
+
+    #endregion
+
+    #region ReadNull (internal)
+
+    /// <summary>
+    /// Verify ReadNull returns null for "null".
+    /// </summary>
+    [Test]
+    public void ReadNull_ReturnsNull()
+    {
+        var reader = CreateReader("null");
+        var result = InvokeGeneric<object>(reader, "ReadNull", new[] { typeof(object) });
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verify ReadNull throws for invalid null literal.
+    /// </summary>
+    [Test]
+    public void ReadNull_Invalid_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("nul");
+        Assert.Throws<TargetInvocationException>(
+            () => InvokeGeneric<object>(reader, "ReadNull", new[] { typeof(object) }));
+    }
+
+    #endregion
+
+    #region ReadJsonPropertyName
+
+    /// <summary>
+    /// Verify ReadJsonPropertyName returns the correct property name.
+    /// JsonPropertyName.Name is internal, so we access it via reflection.
+    /// </summary>
+    [Test]
+    public void ReadJsonPropertyName_ReturnsName()
+    {
+        var reader = CreateReader("\"name\": 42");
+        var prop = Invoke<object>(reader, "ReadJsonPropertyName");
+        // Access internal Name property via reflection (NonPublic binding flags needed)
+        var nameProp = prop.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        var nameValue = nameProp.GetValue(prop);
+        Assert.AreEqual("name", nameValue.ToString());
+
+        // After reading property name, reader is positioned after ':'. 
+        // Skip any whitespace before reading the value.
+        InvokeVoid(reader, "SkipWhitespace");
+        var numResult = Invoke<object>(reader, "ReadNumber");
+        Assert.AreEqual("42", numResult.ToString());
+    }
+
+    /// <summary>
+    /// Verify ReadJsonPropertyName throws when not starting with a quote.
+    /// </summary>
+    [Test]
+    public void ReadJsonPropertyName_NotQuoted_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("name: 42");
+        Assert.Throws<TargetInvocationException>(() => Invoke<object>(reader, "ReadJsonPropertyName"));
+    }
+
+    /// <summary>
+    /// Verify ReadJsonPropertyName throws when missing colon after name.
+    /// </summary>
+    [Test]
+    public void ReadJsonPropertyName_MissingColon_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("\"name\" 42");
+        Assert.Throws<TargetInvocationException>(() => Invoke<object>(reader, "ReadJsonPropertyName"));
+    }
+
+    #endregion
+
+    #region ReadContent
+
+    /// <summary>
+    /// Verify ReadContent iterates over all properties in a JSON object.
+    /// Uses reflection because ReadContent returns internal types.
+    /// </summary>
+    [Test]
+    public void ReadContent_IteratesProperties()
+    {
+        var reader = CreateReader("{\"name\":\"LHZ\",\"age\":30}");
+        var keys = new List<string>();
+        var types = new List<JsonType>();
+
+        // ReadContent returns IEnumerable<KeyValuePair<JsonPropertyName, JsonDirectReader>>
+        // Both are internal, so iterate as non-generic IEnumerable and use reflection
+        var enumerable = (System.Collections.IEnumerable)ReaderType.GetMethod("ReadContent", MethodFlags).Invoke(reader, null);
+        foreach (var kvpObj in enumerable)
+        {
+            // Get Key and Value from KeyValuePair via reflection
+            var kvpType = kvpObj.GetType();
+            var keyObj = kvpType.GetProperty("Key").GetValue(kvpObj);
+            var valReader = kvpType.GetProperty("Value").GetValue(kvpObj);
+
+            // Access JsonPropertyName.Name (internal) via reflection
+            var nameProp = keyObj.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            var nameValue = nameProp.GetValue(keyObj);
+            keys.Add(nameValue.ToString());
+
+            types.Add(GetProp<JsonType>(valReader, "JsonType"));
+            // Must consume the value so enumeration advances
+            InvokeVoid(valReader, "SkipCurrentObject");
+        }
+
+        Assert.AreEqual(new[] { "name", "age" }, keys.ToArray());
+        Assert.AreEqual(new[] { JsonType.String, JsonType.Number }, types.ToArray());
+    }
+
+    /// <summary>
+    /// Verify ReadContent handles an empty object.
+    /// </summary>
+    [Test]
+    public void ReadContent_EmptyObject()
+    {
+        var reader = CreateReader("{}");
+        var enumerable = (System.Collections.IEnumerable)ReaderType.GetMethod("ReadContent", MethodFlags).Invoke(reader, null);
+        int count = 0;
+        foreach (var _ in enumerable) count++;
+        Assert.AreEqual(0, count);
+    }
+
+    /// <summary>
+    /// Verify ReadContent handles nested objects.
+    /// </summary>
+    [Test]
+    public void ReadContent_NestedObject()
+    {
+        var json = "{\"outer\":{\"inner\":\"value\"}}";
+        var reader = CreateReader(json);
+        var enumerable = (System.Collections.IEnumerable)ReaderType.GetMethod("ReadContent", MethodFlags).Invoke(reader, null);
+
+        int count = 0;
+        foreach (var kvpObj in enumerable)
+        {
+            count++;
+            var kvpType = kvpObj.GetType();
+            var keyObj = kvpType.GetProperty("Key").GetValue(kvpObj);
+            var valReader = kvpType.GetProperty("Value").GetValue(kvpObj);
+
+            // Access internal Name property
+            var nameProp = keyObj.GetType().GetProperty("Name", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            Assert.AreEqual("outer", nameProp.GetValue(keyObj).ToString());
+
+            // item.Value is positioned at '{'
+            Assert.AreEqual(JsonType.Content, GetProp<JsonType>(valReader, "JsonType"));
+            // Must consume the nested object so enumeration advances
+            InvokeVoid(valReader, "SkipCurrentObject");
+        }
+        Assert.AreEqual(1, count);
+    }
+
+    #endregion
+
+    #region ReadArray
+
+    /// <summary>
+    /// Verify ReadArray iterates over all elements in a JSON array.
+    /// </summary>
+    [Test]
+    public void ReadArray_IteratesElements()
+    {
+        var reader = CreateReader("[1, 2, 3]");
+        var values = new List<string>();
+
+        var enumerable = (System.Collections.IEnumerable)ReaderType.GetMethod("ReadArray", MethodFlags).Invoke(reader, null);
+        foreach (var item in enumerable)
+        {
+            // item is the same JsonDirectReader instance (yield return this)
+            // ReadNumber is internal, call via reflection
+            var result = Invoke<object>(item, "ReadNumber");
+            values.Add(result.ToString());
+        }
+
+        Assert.AreEqual(new[] { "1", "2", "3" }, values.ToArray());
+    }
+
+    /// <summary>
+    /// Verify ReadArray handles an empty array.
+    /// </summary>
+    [Test]
+    public void ReadArray_EmptyArray()
+    {
+        var reader = CreateReader("[]");
+        var enumerable = (System.Collections.IEnumerable)ReaderType.GetMethod("ReadArray", MethodFlags).Invoke(reader, null);
+        int count = 0;
+        foreach (var _ in enumerable) count++;
+        Assert.AreEqual(0, count);
+    }
+
+    /// <summary>
+    /// Verify ReadArray handles mixed types.
+    /// </summary>
+    [Test]
+    public void ReadArray_MixedTypes()
+    {
+        var reader = CreateReader("[\"text\", 42, true, null]");
+
+        var enumerable = (System.Collections.IEnumerable)ReaderType.GetMethod("ReadArray").Invoke(reader, null);
+        var types = new List<JsonType>();
+        foreach (var item in enumerable)
+        {
+            types.Add(GetProp<JsonType>(item, "JsonType"));
+            // Must consume the value so the next iteration advances correctly
+            InvokeVoid(item, "SkipCurrentObject");
+        }
+
+        Assert.AreEqual(new[] { JsonType.String, JsonType.Number, JsonType.Boolean, JsonType.Null }, types.ToArray());
+    }
+
+    /// <summary>
+    /// Verify ReadArray handles an array of objects.
+    /// Note: nested arrays like [[1,2],[3,4]] are not fully supported by ReadArray
+    /// because it skips consecutive '[' characters (known behavior).
+    /// </summary>
+    [Test]
+    public void ReadArray_ArrayOfObjects()
+    {
+        var reader = CreateReader("[{\"a\":1},{\"b\":2}]");
+
+        var outer = (System.Collections.IEnumerable)ReaderType.GetMethod("ReadArray", MethodFlags).Invoke(reader, null);
+        int outerCount = 0;
+        foreach (var outerItem in outer)
+        {
+            outerCount++;
+            Assert.AreEqual(JsonType.Content, GetProp<JsonType>(outerItem, "JsonType"));
+            // Must consume the content object so enumeration advances
+            InvokeVoid(outerItem, "SkipCurrentObject");
+        }
+        Assert.AreEqual(2, outerCount);
+    }
+
+    #endregion
+
+    #region SkipCurrentObject
+
+    /// <summary>
+    /// Verify SkipCurrentObject skips a simple value.
+    /// </summary>
+    [Test]
+    public void SkipCurrentObject_SkipsString()
+    {
+        var reader = CreateReader("\"skip\"");
+        InvokeVoid(reader, "SkipCurrentObject");
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify SkipCurrentObject skips a number.
+    /// </summary>
+    [Test]
+    public void SkipCurrentObject_SkipsNumber()
+    {
+        var reader = CreateReader("12345");
+        InvokeVoid(reader, "SkipCurrentObject");
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify SkipCurrentObject skips a nested object (note: array skip has a known bug
+    /// in the source where ReadContent is called instead of ReadArray for '[').
+    /// </summary>
+    [Test]
+    public void SkipCurrentObject_SkipsObject()
+    {
+        var reader = CreateReader("{\"a\":1,\"b\":\"x\"}");
+        InvokeVoid(reader, "SkipCurrentObject");
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify SkipCurrentObject on a boolean value.
+    /// </summary>
+    [Test]
+    public void SkipCurrentObject_SkipsBoolean()
+    {
+        var reader = CreateReader("true");
+        InvokeVoid(reader, "SkipCurrentObject");
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+
+        reader = CreateReader("false");
+        InvokeVoid(reader, "SkipCurrentObject");
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify SkipCurrentObject on null.
+    /// </summary>
+    [Test]
+    public void SkipCurrentObject_SkipsNull()
+    {
+        var reader = CreateReader("null");
+        InvokeVoid(reader, "SkipCurrentObject");
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    /// <summary>
+    /// Verify SkipCurrentObject skips one element in a sequence (via array).
+    /// </summary>
+    [Test]
+    public void SkipCurrentObject_SkipsOneElementInSequence()
+    {
+        var reader = CreateReader("42");
+        InvokeVoid(reader, "SkipCurrentObject");
+        Assert.IsTrue(GetProp<bool>(reader, "IsReadEnd"));
+    }
+
+    #endregion
+
+    #region ReadAsJsonObject
+
+    /// <summary>
+    /// Verify ReadAsJsonObject returns a valid JsonObject tree.
+    /// </summary>
+    [Test]
+    public void ReadAsJsonObject_ReturnsJsonObject()
+    {
+        var reader = CreateReader("{\"name\":\"LHZ\"}");
+        var result = Invoke<JsonObject>(reader, "ReadAsJsonObject");
+        Assert.IsNotNull(result);
+        Assert.AreEqual(JsonType.Content, result.Type);
+        Assert.AreEqual("LHZ", result["name"].Value);
+    }
+
+    /// <summary>
+    /// Verify ReadAsJsonObject handles arrays.
+    /// </summary>
+    [Test]
+    public void ReadAsJsonObject_Array()
+    {
+        var reader = CreateReader("[1, 2, 3]");
+        var result = Invoke<JsonObject>(reader, "ReadAsJsonObject");
+        Assert.IsNotNull(result);
+        Assert.AreEqual(JsonType.Array, result.Type);
+    }
+
+    /// <summary>
+    /// Verify ReadAsJsonObject handles all primitive types.
+    /// </summary>
+    [Test]
+    public void ReadAsJsonObject_Primitives()
+    {
+        var reader = CreateReader("\"hello\"");
+        var result = Invoke<JsonObject>(reader, "ReadAsJsonObject");
+        Assert.AreEqual(JsonType.String, result.Type);
+        Assert.AreEqual("hello", result.Value);
+
+        reader = CreateReader("true");
+        result = Invoke<JsonObject>(reader, "ReadAsJsonObject");
+        Assert.AreEqual(JsonType.Boolean, result.Type);
+        Assert.AreEqual(true, result.Value);
+
+        reader = CreateReader("null");
+        result = Invoke<JsonObject>(reader, "ReadAsJsonObject");
+        Assert.AreEqual(JsonType.Null, result.Type);
+    }
+
+    #endregion
+
+    #region Integration Tests (via JsonConvert)
+
+    /// <summary>
+    /// Verify that deserialization through JsonConvert works correctly,
+    /// which internally exercises JsonDirectReader.
+    /// </summary>
+    [Test]
+    public void Integration_DeserializeSimpleObject()
+    {
+        var json = "{\"Id\":1,\"Name\":\"LHZ\"}";
+        var obj = JsonConvert.Deserialize<TestObjClass>(json);
+        Assert.AreEqual(1, obj.Id);
+        Assert.AreEqual("LHZ", obj.Name);
+    }
+
+    /// <summary>
+    /// Verify deserialization of nullable types.
+    /// </summary>
+    [Test]
+    public void Integration_DeserializeNullableModel()
+    {
+        var json = "{\"Count\":null,\"ExpiryDate\":null,\"Rating\":null,\"Name\":null}";
+        var obj = JsonConvert.Deserialize<NullableModel>(json);
+        Assert.IsNull(obj.Count);
+        Assert.IsNull(obj.ExpiryDate);
+        Assert.IsNull(obj.Rating);
+        Assert.IsNull(obj.Name);
+    }
+
+    /// <summary>
+    /// Verify deserialization of an array.
+    /// </summary>
+    [Test]
+    public void Integration_DeserializeArray()
+    {
+        var json = "[10, 20, 30]";
+        var arr = JsonConvert.Deserialize<int[]>(json);
+        Assert.AreEqual(new[] { 10, 20, 30 }, arr);
+    }
+
+    /// <summary>
+    /// Verify deserialization of a list of objects.
+    /// </summary>
+    [Test]
+    public void Integration_DeserializeList()
+    {
+        var json = "[{\"Name\":\"A\",\"Age\":1,\"Height\":1.5,\"Obj\":null},{\"Name\":\"B\",\"Age\":2,\"Height\":2.5,\"Obj\":null}]";
+        var list = JsonConvert.Deserialize<List<TestMultiProtertyObj>>(json);
+        Assert.AreEqual(2, list.Count);
+        Assert.AreEqual("A", list[0].Name);
+        Assert.AreEqual(1, list[0].Age);
+        Assert.AreEqual("B", list[1].Name);
+        Assert.AreEqual(2, list[1].Age);
+    }
+
+    /// <summary>
+    /// Verify deserialization of a dictionary.
+    /// </summary>
+    [Test]
+    public void Integration_DeserializeDictionary()
+    {
+        var json = "{\"key1\":100,\"key2\":200}";
+        var dict = JsonConvert.Deserialize<Dictionary<string, int>>(json);
+        Assert.AreEqual(100, dict["key1"]);
+        Assert.AreEqual(200, dict["key2"]);
+    }
+
+    /// <summary>
+    /// Verify deserialization of nested objects.
+    /// </summary>
+    [Test]
+    public void Integration_DeserializeNestedObject()
+    {
+        var json = "{\"Name\":\"Parent\",\"Child\":{\"Name\":\"Child\",\"Age\":10}}";
+        var obj = JsonConvert.Deserialize<NestedTestObj>(json);
+        Assert.AreEqual("Parent", obj.Name);
+        Assert.IsNotNull(obj.Child);
+        Assert.AreEqual("Child", obj.Child.Name);
+        Assert.AreEqual(10, obj.Child.Age);
+    }
+
+    #endregion
+
+    #region Error Handling
+
+    /// <summary>
+    /// Verify JsonType throws for unknown characters.
+    /// </summary>
+    [Test]
+    public void JsonType_UnknownChar_ThrowsException()
+    {
+        var reader = CreateReader("!invalid");
+        Assert.Throws<TargetInvocationException>(() => GetProp<JsonType>(reader, "JsonType"));
+    }
+
+    /// <summary>
+    /// Verify malformed unicode escape throws.
+    /// </summary>
+    [Test]
+    public void ReadString_MalformedUnicode_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("\"\\u00ZZ\"");
+        Assert.Throws<TargetInvocationException>(() => Invoke<string>(reader, "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify unknown escape character throws.
+    /// </summary>
+    [Test]
+    public void ReadString_UnknownEscape_ThrowsJsonReadException()
+    {
+        var reader = CreateReader("\"\\x\"");
+        Assert.Throws<TargetInvocationException>(() => Invoke<string>(reader, "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify unescaped control character throws.
+    /// </summary>
+    [Test]
+    public void ReadString_ControlCharacter_ThrowsJsonReadException()
+    {
+        // 0x01 is a control character that should be rejected in JSON strings
+        var json = "\"\u0001\"";
+        var reader = CreateReader(json);
+        Assert.Throws<TargetInvocationException>(() => Invoke<string>(reader, "ReadString"));
+    }
+
+    /// <summary>
+    /// Verify deserializing wrong type throws an exception.
+    /// </summary>
+    [Test]
+    public void Integration_TypeMismatch_ThrowsException()
+    {
+        Assert.Throws<JsonDirectDeserializationException>(
+            () => JsonConvert.Deserialize<int>("\"not a number\""));
+    }
+
+    #endregion
+}

--- a/src/LHZ.FastJson.UnitTest/TestJsonReder.cs
+++ b/src/LHZ.FastJson.UnitTest/TestJsonReder.cs
@@ -69,7 +69,7 @@ namespace LHZ.FastJson.UnitTest
             reader = new JsonReader(str);
             var result = reader.JsonRead();
             Assert.AreEqual(result.ToString(), str);
-            
+
         }
 
         /// <summary>
@@ -239,5 +239,20 @@ namespace LHZ.FastJson.UnitTest
             Assert.IsFalse(JsonReader.IsJsonString("   ", out exception));
             Assert.IsNotNull(exception);
             Assert.IsInstanceOf<LHZ.FastJson.Exceptions.JsonReadException>(exception);
-        }    }
+        }
+        /// <summary>
+        /// 验证读取部分json字符串
+        /// </summary>
+        [Test]
+        public void PartOfJsonRead()
+        {
+            var jsonStr = "{\"Name\":\"LHZ\",\"Age\":10,\"Tags\":[{},{},{}]}";
+            var jsonObj = (new JsonReader(jsonStr, 20)).JsonRead();
+            Assert.AreEqual(jsonObj.Type, JsonType.Number);
+            Assert.AreEqual(jsonObj.Value.ToString(), "10");
+            jsonObj = (new JsonReader(jsonStr, 30)).JsonRead();
+            Assert.AreEqual(jsonObj.Type, JsonType.Array);
+            Assert.AreEqual(((JsonArray)jsonObj).Length, 3);
+        }
+    }
 }

--- a/src/LHZ.FastJson/Exceptions/JsonDirectDeserializationException.cs
+++ b/src/LHZ.FastJson/Exceptions/JsonDirectDeserializationException.cs
@@ -1,0 +1,32 @@
+using System;
+using LHZ.FastJson.Enum;
+
+namespace LHZ.FastJson.Exceptions
+{
+    public class JsonDirectDeserializationException : JsonReadException
+    {
+        private JsonType _jsonType;
+        //private ObjectType _objType;
+        private Type _targetType;
+        /// <summary>
+        /// Initialize JSON deserialization exception
+        /// </summary>
+        /// <param name="Position">Position</param>
+        /// <param name="targetType">Target type</param>
+        /// <param name="msg">Exception message</param>
+        public JsonDirectDeserializationException(int Position, JsonType jsonType, Type targetType, string msg) : base(Position, msg)
+        {
+            this._targetType = targetType;
+            this._jsonType = jsonType;
+        }
+
+        /// <summary>
+        /// JSON type
+        /// </summary>
+        public JsonType JsonType { get { return this._jsonType; } }
+        /// <summary>
+        /// Target type
+        /// </summary>
+        public Type TargetType { get { return this._targetType; } }
+    }
+}

--- a/src/LHZ.FastJson/Extend/JsonCommonExtend.cs
+++ b/src/LHZ.FastJson/Extend/JsonCommonExtend.cs
@@ -13,16 +13,16 @@ namespace LHZ.FastJson
     public static class JsonCommonExtend
     {
 
-        /// <summary>
-        /// Convert a JSON object to the target object
-        /// </summary>
-        /// <typeparam name="T">The target object type to convert to</typeparam>
-        /// <returns>The target object</returns>
-        public static T ToObject<T>(this IJsonObject jsonObj)
-        {
-            JsonDeserializer<T> deserializer = new JsonDeserializer<T>(jsonObj);
-            return deserializer.Deserialize();
-        }
+        // /// <summary>
+        // /// Convert a JSON object to the target object
+        // /// </summary>
+        // /// <typeparam name="T">The target object type to convert to</typeparam>
+        // /// <returns>The target object</returns>
+        // public static T ToObject<T>(this IJsonObject jsonObj)
+        // {
+        //     JsonDeserializer<T> deserializer = new JsonDeserializer<T>(jsonObj);
+        //     return deserializer.Deserialize();
+        // }
 
         /// <summary>
         /// Deserialize a JSON string into a T object

--- a/src/LHZ.FastJson/Json/JsonDeserializer.cs
+++ b/src/LHZ.FastJson/Json/JsonDeserializer.cs
@@ -21,31 +21,15 @@ namespace LHZ.FastJson.Json
     /// <typeparam name="T">The class to deserialize</typeparam>
     public class JsonDeserializer<T>
     {
-        private IJsonObject _obj;
-        /// <summary>
-        /// Initialize with a JSON object
-        /// </summary>
-        /// <param name="obj">Parsed JSON object</param>
-        public JsonDeserializer(IJsonObject obj)
-        {
-            this._obj = obj;
-        }
-        /// <summary>
-        /// Initialize with a JsonReader
-        /// </summary>
-        /// <param name="reader">JSON reader</param>
-        public JsonDeserializer(JsonReader reader)
-        {
-            this._obj = reader.JsonRead();
-        }
+        private readonly JsonDirectReader _obj;
         /// <summary>
         /// Initialize with a JSON string
         /// </summary>
         /// <param name="jsonString">JSON string</param>
         public JsonDeserializer(string jsonString)
         {
-            JsonReader reader = new JsonReader(jsonString);
-            this._obj = reader.JsonRead();
+            JsonDirectReader reader = new JsonDirectReader(jsonString);
+            this._obj = reader;
         }
 
         /// <summary>
@@ -74,7 +58,7 @@ namespace LHZ.FastJson.Json
                     }
                 }
             }
-            return JsonDeserialzerExpression<T>.Deserialzer(_obj, customConverters);
+            return JsonDirectDeserialzerExpression<T>.Deserialzer(_obj, customConverters);
         }
     }
 }

--- a/src/LHZ.FastJson/Json/JsonDirectDeserialzerExpression.cs
+++ b/src/LHZ.FastJson/Json/JsonDirectDeserialzerExpression.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using LHZ.FastJson;
 using LHZ.FastJson.Enum;
 using LHZ.FastJson.Exceptions;
@@ -718,53 +719,42 @@ namespace LHZ.FastJson.Json
                 Expression.Constant("Json对象不为Content类型不能解析成Object类型")))));
 
             //Get writable properties and create variables for each
-            var properties = curType.GetProperties().Where(n => n.CanWrite).ToList();
+            var groups = curType.GetProperties()
+            .Where(n => n.CanWrite)
+            //Ignore Attribute
+            .Where(n => !Attribute.GetCustomAttributes(n).Any(x => x is JsonIgnoredAttribute a && (a.JsonIgnoredMethod & JsonMethods.Deserialize) == JsonMethods.Deserialize))
+            .Select(n => new KeyValuePair<JsonPropertyName, PropertyInfo>(new JsonPropertyName(n.Name), n))
+            .GroupBy(n=>n.Key.HashCode);
             var propVarMap = new Dictionary<System.Reflection.PropertyInfo, ParameterExpression>();
             List<SwitchCase> switchCases = new List<SwitchCase>();
-            foreach (var item in properties)
+            foreach(var item in groups)
             {
-                //Check if deserialization should be ignored
-                var jsonIgnored = Attribute.GetCustomAttribute(item, typeof(JsonIgnoredAttribute)) as JsonIgnoredAttribute;
-                if (jsonIgnored != null && (jsonIgnored.JsonIgnoredMethod & JsonMethods.Deserialize) == JsonMethods.Deserialize)
+                
+                Expression ifExp = null;
+                foreach(var propertie in item)
                 {
-                    continue;
-                }
-
-                var propertyValue = Expression.Variable(item.PropertyType, item.Name + "propertyValue");
-                variables.Add(propertyValue);
-                propVarMap[item] = propertyValue;
-                bindings.Add(Expression.Bind(item, propertyValue));
-
-                #region Custom property name handling
-                JsonClass.Internal.StringView jsonPropertyNameStringView = new JsonClass.Internal.StringView(JsonUtility.GetPropertyName(item));
-                var jsonPropertyName = new JsonPropertyName(jsonPropertyNameStringView, jsonPropertyNameStringView.GetHashCode());
-                #endregion
-
-                
-
-                var opEquality = typeof(JsonPropertyName).GetMethod("op_Equality");
-                var deserializerMethod = typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(item.PropertyType)
+                    var propertyValue = Expression.Variable(propertie.Value.PropertyType, propertie.Value.Name + "propertyValue");
+                    variables.Add(propertyValue);
+                    propVarMap[propertie.Value] = propertyValue;
+                    bindings.Add(Expression.Bind(propertie.Value, propertyValue));
+                    var deserializerMethod = typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(propertie.Value.PropertyType)
                     .GetMethod("Deserialzer", new Type[] { typeof(JsonDirectReader), typeof(Dictionary<Type, IJsonCustomConverter>) });
-
-                switchCases.Add(Expression.SwitchCase(Expression.Assign(propertyValue, Expression.Call(deserializerMethod, Expression.Property(kvp, "Value"), jsonCustomConvertersParameter)),
-                Expression.Constant(jsonPropertyName.HashCode)));
-                
-                
-                // // if (kvp.Key == jsonPropertyName) propertyValue = Deserialzer(kvp.Value, customConverters)
-                // loopBody.Add(Expression.IfThen(
-                //     Expression.Call(opEquality, Expression.Property(kvp, "Key"), Expression.Constant(jsonPropertyName)),
-                //     Expression.Assign(propertyValue, Expression.Call(deserializerMethod, Expression.Property(kvp, "Value"), jsonCustomConvertersParameter))));
+                    if(ifExp == null)
+                    {
+                        ifExp = Expression.IfThenElse(Expression.Equal(Expression.Constant(propertie.Key), Expression.Property(kvp, "Key")),
+                            Expression.Assign(propertyValue, Expression.Call(deserializerMethod, Expression.Property(kvp, "Value"), jsonCustomConvertersParameter)),
+                            Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value));
+                    }
+                    else
+                    {
+                        ifExp = Expression.IfThenElse(Expression.Equal(Expression.Constant(propertie.Key), Expression.Property(kvp, "Key")),
+                            Expression.Assign(propertyValue, Expression.Call(deserializerMethod, Expression.Property(kvp, "Value"), jsonCustomConvertersParameter)),
+                            ifExp);
+                    }
+                }
+                switchCases.Add(Expression.SwitchCase(ifExp,Expression.Constant(item.Key)));
             }
-            try
-            {
-                //Expression.Switch(typeof(void), Expression.Constant("SwitchValue"), null, null, cases);
-                loopBody.Add(Expression.Switch(typeof(void), Expression.Call(Expression.Property(kvp, "Key"), "GetHashCode", EmptyArray<Type>.Value), Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), null, switchCases.ToArray()));
-            }
-            catch (Exception ex)
-            {
-
-            }
-            // enumerator = reader.ReadContent().GetEnumerator()
+            loopBody.Add(Expression.Switch(typeof(void), Expression.Call(Expression.Property(kvp, "Key"), "GetHashCode", EmptyArray<Type>.Value), Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), null, switchCases.ToArray()));
             expres.Add(Expression.Assign(enumerator,
                 Expression.Call(
                     Expression.Call(jsonObjectParameter, typeof(JsonDirectReader).GetMethod("ReadContent")),

--- a/src/LHZ.FastJson/Json/JsonDirectDeserialzerExpression.cs
+++ b/src/LHZ.FastJson/Json/JsonDirectDeserialzerExpression.cs
@@ -1,0 +1,818 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using LHZ.FastJson;
+using LHZ.FastJson.Enum;
+using LHZ.FastJson.Exceptions;
+using LHZ.FastJson.Interface;
+using LHZ.FastJson.Json.Attributes;
+using LHZ.FastJson.Json.Utils;
+using LHZ.FastJson.JsonClass;
+using LHZ.FastJson.Utils;
+
+namespace LHZ.FastJson.Json
+{
+    internal class JsonDirectDeserialzerExpression<T>
+    {
+        private static readonly Dictionary<Type, ObjectType> _objectTypes = JsonObjectType.GetObjectTypes();
+
+        private static readonly Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T> _funcDeserialize = null;
+        private static readonly Type _type = typeof(T);
+
+        static JsonDirectDeserialzerExpression()
+        {
+            var funcDeserializeExpression = CreateExpression();
+            _funcDeserialize = funcDeserializeExpression.Compile();
+        }
+
+        public static T Deserialzer(JsonDirectReader jsonObject)
+        {
+            // if(jsonObject.IsReadEnd)
+            //     return default(T);
+            return _funcDeserialize(jsonObject, null);
+        }
+        public static T Deserialzer(JsonDirectReader jsonObject, Dictionary<Type, IJsonCustomConverter> jsonCustomConverters)
+        {
+            // if(jsonObject.IsReadEnd)
+            //     return default(T);
+            if (jsonCustomConverters != null && jsonCustomConverters.TryGetValue(_type, out IJsonCustomConverter customConverter))
+            {
+                return (T)customConverter.Deserialize(jsonObject.ReadAsJsonObject());
+            }
+            return _funcDeserialize(jsonObject, jsonCustomConverters);
+        }
+
+        /// <summary>
+        /// Get deserialization expression tree
+        /// </summary>
+        /// <returns></returns>
+        private static Expression<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>> CreateExpression()
+        {
+            ParameterExpression jsonObjectParameter = Expression.Parameter(typeof(JsonDirectReader), "jsonDirectReader");
+            ParameterExpression jsonCustomConvertersParameter = Expression.Parameter(typeof(Dictionary<Type, IJsonCustomConverter>), "jsonCustomConverters");
+            var curType = _type;
+            ObjectType objectType = GetObjectType(curType);
+            switch (objectType)
+            {
+                case ObjectType.Boolean:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, bool>)ConvertToBoolean).Method, jsonObjectParameter), jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Byte:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, byte>)ConvertToByte).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Char:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, char>)ConvertToChar).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Int16:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, short>)ConvertToInt16).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.UInt16:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, ushort>)ConvertToUInt16).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Int32:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, int>)ConvertToInt32).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.UInt32:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, uint>)ConvertToUInt32).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Int64:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, long>)ConvertToInt64).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.UInt64:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, ulong>)ConvertToUInt64).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Float:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, float>)ConvertToFloat).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Double:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, double>)ConvertToDouble).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Decimal:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, decimal>)ConvertToDecimal).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.DateTime:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, DateTime>)ConvertToDateTime).Method, jsonObjectParameter), jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Guid:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call(
+                        ((Func<JsonDirectReader, Guid>)ConvertToGuid).Method, jsonObjectParameter), jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.String:
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Call( 
+                        ((Func<JsonDirectReader, string>)ConvertToString).Method, jsonObjectParameter),  jsonObjectParameter, jsonCustomConvertersParameter);
+                case ObjectType.Enum: return ConvertToEnum();
+                case ObjectType.Nullable: return ConvertToNullable();
+                case ObjectType.Dictionary: return ConvertToDictionary();
+                case ObjectType.Array: return ConvertToArray();
+                case ObjectType.List: return ConvertToList();
+                //case ObjectType.Enumerable:  
+                default:
+                    return ConvertToObject();
+            }
+        }
+        /// <summary>
+        /// Get the type of the object
+        /// </summary>
+        /// <param name="type">Deserialization object type</param>
+        /// <returns></returns>
+        private static ObjectType GetObjectType(Type type)
+        {
+            ObjectType objType;
+            if (JsonObjectType.ObjectTypes.TryGetValue(type, out objType))
+            {
+                return objType;
+            }
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                return ObjectType.Nullable;
+            else if (type.IsEnum)
+                return ObjectType.Enum;
+            else if (typeof(IDictionary).IsAssignableFrom(type))
+                return ObjectType.Dictionary;
+            else if (type.IsArray)
+                return ObjectType.Array;
+            else if (typeof(IList).IsAssignableFrom(type))
+                return ObjectType.List;
+            else if (type == typeof(Guid))
+                return ObjectType.Guid;
+            //else if (typeof(IEnumerable).IsAssignableFrom(type))
+            //    return ObjectType.Enumerable;
+            else
+                return ObjectType.Object;
+
+        }
+
+        /// <summary>
+        /// Parse to bool type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static bool ConvertToBoolean(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Boolean)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(bool), "Json对象不为Boolean类型不能解析成Boolean类型");
+            }
+            return jsonDirectReader.ReadBoolean();
+        }
+
+        /// <summary>
+        /// Parse to byte type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static byte ConvertToByte(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(Byte), "Json对象不为Number类型不能解析成Byte类型");
+            }
+            return jsonDirectReader.ReadNumber().ToByte(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parse to char type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static char ConvertToChar(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.String)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(Char), "Json对象不为String类型不能解析成Char类型");
+            }
+            var str = jsonDirectReader.ReadString();
+            if (str.Length != 1)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(Char), "Json对象字符串长度不等于1，不能解析成Char类型");
+            }
+            return str[0];
+        }
+
+        /// <summary>
+        /// Parse to int16 type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static short ConvertToInt16(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(Int16), "Json对象不为Number类型不能解析成Int16类型");
+            }
+            return jsonDirectReader.ReadNumber().ToInt16(CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Parse to uint16 type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static ushort ConvertToUInt16(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(UInt16), "Json对象不为Number类型不能解析成UInt16类型");
+            }
+            return jsonDirectReader.ReadNumber().ToUInt16(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parse to int32 type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static int ConvertToInt32(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(int), "Json对象不为Number类型不能解析成Int32类型");
+            }
+            return jsonDirectReader.ReadNumber().ToInt32(CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Parse to uint32 type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static uint ConvertToUInt32(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(uint), "Json对象不为Number类型不能解析成UInt32类型");
+            }
+            return jsonDirectReader.ReadNumber().ToUInt32(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parse to int64 type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static long ConvertToInt64(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(long), "Json对象不为Number类型不能解析成Int64类型");
+            }
+            return jsonDirectReader.ReadNumber().ToInt64(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parse to uint64 type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static ulong ConvertToUInt64(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(ulong), "Json对象不为Number类型不能解析成UInt64类型");
+            }
+            return jsonDirectReader.ReadNumber().ToUInt64(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parse to single-precision floating-point type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static float ConvertToFloat(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(float), "Json对象不为Number类型不能解析成Float类型");
+            }
+            return jsonDirectReader.ReadNumber().ToSingle(CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Parse to double-precision floating-point type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static double ConvertToDouble(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(double), "Json对象不为Number类型不能解析成Double类型");
+            }
+            return jsonDirectReader.ReadNumber().ToDouble(CultureInfo.InvariantCulture);
+        }
+        /// <summary>
+        /// Parse to decimal type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static decimal ConvertToDecimal(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.Number)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(decimal), "Json对象不为Number类型不能解析成Decimal类型");
+            }
+            return jsonDirectReader.ReadNumber().ToDecimal(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Parse to DateTime type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static DateTime ConvertToDateTime(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.String)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(DateTime), "Json对象不为String类型不能解析成DateTime类型");
+            }
+            return DateTime.Parse(jsonDirectReader.ReadString(), CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Parse to enum
+        /// </summary>
+        /// <returns></returns>
+        private static object ConvertToEnum(JsonDirectReader jsonDirectReader)
+        {
+            var type = _type;
+            if (jsonDirectReader.JsonType == JsonType.String)
+            {
+                EnumConverter converter = new EnumConverter(type);
+                return converter.ConvertFromString(jsonDirectReader.ReadString());
+            }
+            else if (jsonDirectReader.JsonType == JsonType.Number)
+            {
+                int value = jsonDirectReader.ReadNumber().ToInt32(CultureInfo.InvariantCulture);
+                if (!System.Enum.IsDefined(type, value))
+                {
+                    throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, type, "当前Number数字，在枚举中未定义");
+                }
+                return System.Enum.ToObject(type, value);
+            }
+            else
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, type, "Json对象的" + jsonDirectReader.JsonType.ToString() + "类型不能解析成Enum类型");
+            }
+        }
+        /// <summary>
+        /// Parse to GUID type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static Guid ConvertToGuid(JsonDirectReader jsonDirectReader)
+        {
+            if (jsonDirectReader.JsonType != JsonType.String)
+            {
+                throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(Guid), "Json对象不为String类型不能解析成Guid类型");
+            }
+            return Guid.Parse(jsonDirectReader.ReadString());
+        }
+        /// <summary>
+        /// Parse to enum
+        /// </summary>
+        /// <returns>Enum</returns>
+        private static Expression<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>> ConvertToEnum()
+        {
+            ParameterExpression jsonObjectParameter = Expression.Parameter(typeof(JsonDirectReader), "jsonDirectReader");
+            ParameterExpression jsonCustomConvertersParameter = Expression.Parameter(typeof(Dictionary<Type, IJsonCustomConverter>), "jsonCustomConverters");
+
+            return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(
+                Expression.Convert(
+                    Expression.Call(((Func<JsonDirectReader, object>)ConvertToEnum).Method, jsonObjectParameter),
+                    _type),
+                jsonObjectParameter, jsonCustomConvertersParameter);
+        }
+
+
+
+
+        /// <summary>
+        /// Parse to string type
+        /// </summary>
+        /// <param name="jsonDirectReader">JSON Direct Reader</param>
+        /// <returns></returns>
+        private static string ConvertToString(JsonDirectReader jsonDirectReader)
+        {
+            switch(jsonDirectReader.JsonType)
+            {
+                case JsonType.String : return jsonDirectReader.ReadString();
+                case JsonType.Null : return jsonDirectReader.ReadNull<string>();
+                default: throw new JsonDirectDeserializationException(jsonDirectReader.Position, jsonDirectReader.JsonType, typeof(string), "Json对象不为String类型不能解析成String类型");
+            }
+        }
+
+        /// <summary>
+        /// Parse to dictionary type
+        /// </summary>
+        /// <returns>Deserialized dictionary expression</returns>
+        private static Expression<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>> ConvertToDictionary()
+        {
+            ParameterExpression jsonObjectParameter = Expression.Parameter(typeof(JsonDirectReader), "jsonDirectReader");
+            ParameterExpression jsonCustomConvertersParameter = Expression.Parameter(typeof(Dictionary<Type, IJsonCustomConverter>), "jsonCustomConverters");
+            var curType = _type;
+            var genericType = typeof(object);
+#if NET40
+
+            Type[] genericTypes = curType.GetGenericArguments();
+#else
+            Type[] genericTypes = curType.GenericTypeArguments;
+#endif
+            if (genericTypes.Length == 2)
+            {
+                genericType = genericTypes[1];
+            }
+
+            var result = Expression.Variable(curType, "result");
+            var enumerator = Expression.Variable(typeof(IEnumerator<KeyValuePair<JsonPropertyName, JsonDirectReader>>), "enumerator");
+            var keyValue = Expression.Variable(typeof(KeyValuePair<JsonPropertyName, JsonDirectReader>), "keyValue");
+            var returnLabel = Expression.Label("returnLable");
+            var loopLabel = Expression.Label("loopLabel");
+
+            List<Expression> expres = new List<Expression>();
+            List<Expression> loopexpres = new List<Expression>();
+
+            //Determine if the JSON object is null
+            expres.Add(Expression.IfThen(Expression.Equal(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Null)),
+                Expression.Block(new Expression[]{Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), Expression.Return(returnLabel)})));
+
+            //Determine if it is JsonContent; if not, throw an exception
+            expres.Add(Expression.IfThen(Expression.NotEqual(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Content)),
+                Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                Expression.Property(jsonObjectParameter, "Position"), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("Json对象不为Content类型不能解析成Dictionary类型")))));
+
+            //Determine if the object can be instantiated
+            if (curType.GetConstructor(EmptyArray<Type>.Value) == null)
+            {
+                expres.Add(Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                Expression.Constant(0), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("反序列化类型没有默认的构造函数，无法创建该类型对象"))));
+                return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(new ParameterExpression[] { result }, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+            }
+            expres.Add(Expression.Assign(result, Expression.New(curType)));
+            expres.Add(Expression.Assign(enumerator, Expression.Call(
+                Expression.Call(jsonObjectParameter, typeof(JsonDirectReader).GetMethod("ReadContent")),
+                typeof(IEnumerable<KeyValuePair<JsonPropertyName, JsonDirectReader>>).GetMethod("GetEnumerator"))));
+
+            loopexpres.Add(Expression.IfThen(Expression.IsFalse(Expression.Call(enumerator, typeof(IEnumerator).GetMethod("MoveNext"))), Expression.Break(loopLabel)));
+            loopexpres.Add(Expression.Assign(keyValue, Expression.Property(enumerator, "Current")));
+
+            //Value types require boxing
+            if (genericType.IsValueType)
+            {
+                loopexpres.Add(Expression.Call(result, typeof(IDictionary).GetMethod("Add", new Type[] { typeof(object), typeof(object) }), Expression.Call(Expression.Property(keyValue, "Key"), "ToString", EmptyArray<Type>.Value),
+                    Expression.Convert(Expression.Call(typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(genericType).GetMethod("Deserialzer", new Type[] { typeof(JsonDirectReader), typeof(Dictionary<Type, IJsonCustomConverter>) }), Expression.Property(keyValue, "Value"), jsonCustomConvertersParameter), typeof(object))));
+            }
+            else
+            {
+                loopexpres.Add(Expression.Call(result, typeof(IDictionary).GetMethod("Add", new Type[] { typeof(object), typeof(object) }), Expression.Call(Expression.Property(keyValue, "Key"), "ToString", EmptyArray<Type>.Value),
+                    Expression.Call(typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(genericType).GetMethod("Deserialzer", new Type[] { typeof(JsonDirectReader), typeof(Dictionary<Type, IJsonCustomConverter>) }), Expression.Property(keyValue, "Value"), jsonCustomConvertersParameter)));
+            }
+
+            expres.Add(Expression.Loop(Expression.Block(loopexpres), loopLabel));
+            expres.Add(Expression.Label(returnLabel));
+            expres.Add(result);
+
+            return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(new ParameterExpression[] { result, enumerator, keyValue }, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+        }
+
+        /// <summary>
+        /// Parse to array
+        /// </summary>
+        /// <returns>Deserialized array expression</returns>
+        private static Expression<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>> ConvertToArray()
+        {
+            ParameterExpression jsonObjectParameter = Expression.Parameter(typeof(JsonDirectReader), "jsonDirectReader");
+            ParameterExpression jsonCustomConvertersParameter = Expression.Parameter(typeof(Dictionary<Type, IJsonCustomConverter>), "jsonCustomConverters");
+
+            var curType = _type;
+            var elementType = curType.GetElementType();
+
+            var result = Expression.Variable(curType, "result");
+            var list = Expression.Variable(typeof(List<>).MakeGenericType(elementType), "list");
+            var enumerator = Expression.Variable(typeof(IEnumerator<JsonDirectReader>), "enumerator");
+            var item = Expression.Variable(typeof(JsonDirectReader), "item");
+            var i = Expression.Variable(typeof(int), "i");
+            var returnLabel = Expression.Label("returnLable");
+            var loopLabel = Expression.Label("loopLabel");
+
+            List<Expression> expres = new List<Expression>();
+            List<Expression> loopexpres = new List<Expression>();
+
+            //Determine if the JSON object is null
+            expres.Add(Expression.IfThen(Expression.Equal(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Null)),
+                Expression.Block(new Expression[]{Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), Expression.Return(returnLabel)})));
+            //Determine if the JSON object is an array type
+            expres.Add(
+            Expression.IfThen(Expression.NotEqual(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Array)),
+                Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                Expression.Property(jsonObjectParameter, "Position"), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("Json对象不为Array类型不能解析成Array类型")))));
+
+            //Initialize list and enumerator
+            expres.Add(Expression.Assign(list, Expression.New(typeof(List<>).MakeGenericType(elementType))));
+            expres.Add(Expression.Assign(enumerator, Expression.Call(
+                Expression.Call(jsonObjectParameter, typeof(JsonDirectReader).GetMethod("ReadArray")),
+                typeof(IEnumerable<JsonDirectReader>).GetMethod("GetEnumerator"))));
+
+            //Loop
+            loopexpres.Add(Expression.IfThen(Expression.IsFalse(Expression.Call(enumerator, typeof(IEnumerator).GetMethod("MoveNext"))), Expression.Break(loopLabel)));
+            loopexpres.Add(Expression.Assign(item, Expression.Convert(Expression.Property(enumerator, "Current"), typeof(JsonDirectReader))));
+            loopexpres.Add(Expression.Call(list, typeof(List<>).MakeGenericType(elementType).GetMethod("Add"),
+                Expression.Call(typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(elementType).GetMethod("Deserialzer", new Type[] { typeof(JsonDirectReader), typeof(Dictionary<Type, IJsonCustomConverter>) }), item, jsonCustomConvertersParameter)));
+
+            expres.Add(Expression.Loop(Expression.Block(loopexpres), loopLabel));
+
+            //Convert list to array
+            expres.Add(Expression.Assign(result, Expression.Call(list, typeof(List<>).MakeGenericType(elementType).GetMethod("ToArray"))));
+            expres.Add(Expression.Label(returnLabel));
+            expres.Add(result);
+            return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(new ParameterExpression[] { list, enumerator, item, result }, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+        }
+        /// <summary>
+        /// Parse to list collection
+        /// </summary>
+        /// <returns>List collection</returns>
+        private static Expression<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>> ConvertToList()
+        {
+            ParameterExpression jsonObjectParameter = Expression.Parameter(typeof(JsonDirectReader), "jsonDirectReader");
+            ParameterExpression jsonCustomConvertersParameter = Expression.Parameter(typeof(Dictionary<Type, IJsonCustomConverter>), "jsonCustomConverters");
+
+            var curType = _type;
+            //Get the generic type
+            var genericType = curType.GetGenericArguments().FirstOrDefault();
+
+            var result = Expression.Variable(curType, "result");
+            var enumerator = Expression.Variable(typeof(IEnumerator<JsonDirectReader>), "enumerator");
+            var item = Expression.Variable(typeof(JsonDirectReader), "item");
+            var returnLabel = Expression.Label("returnLable");
+            var loopLabel = Expression.Label();
+
+            List<Expression> expres = new List<Expression>();
+            List<Expression> loopexpres = new List<Expression>();
+
+            if (genericType == null)
+            {
+                expres.Add(Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType),
+                    typeof(Type), typeof(string) }), Expression.Constant(0), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("泛型列化出错获取List泛型出错！"))));
+                expres.Add(result);
+                return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(new ParameterExpression[] { result }, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+            }
+
+            //Determine if the JSON object is null
+            expres.Add(Expression.IfThen(Expression.Equal(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Null)),
+                Expression.Block(new Expression[]{Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), Expression.Return(returnLabel)})));
+
+            //Determine if the JSON object is an array type
+            expres.Add(
+            Expression.IfThen(Expression.NotEqual(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Array)),
+                Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                Expression.Property(jsonObjectParameter, "Position"), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("Json对象不为Array类型不能解析成List类型")))));
+            //Initialize List and enumerator
+            expres.Add(Expression.Assign(result, Expression.New(curType)));
+            expres.Add(Expression.Assign(enumerator, Expression.Call(
+                Expression.Call(jsonObjectParameter, typeof(JsonDirectReader).GetMethod("ReadArray")),
+                typeof(IEnumerable<JsonDirectReader>).GetMethod("GetEnumerator"))));
+            //Loop to assign List values
+            loopexpres.Add(Expression.IfThen(Expression.IsFalse(Expression.Call(enumerator, typeof(IEnumerator).GetMethod("MoveNext"))), Expression.Break(loopLabel)));
+            loopexpres.Add(Expression.Assign(item, Expression.Convert(Expression.Property(enumerator, "Current"), typeof(JsonDirectReader))));
+            loopexpres.Add(Expression.Call(result, curType.GetMethod("Add", new Type[] { genericType }),
+                Expression.Call(typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(genericType).GetMethod("Deserialzer", new Type[] { typeof(JsonDirectReader), typeof(Dictionary<Type, IJsonCustomConverter>) }), item, jsonCustomConvertersParameter)));
+            expres.Add(Expression.Loop(Expression.Block(loopexpres), loopLabel));
+            expres.Add(Expression.Label(returnLabel));
+            expres.Add(result);
+            return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(new ParameterExpression[] { enumerator, item, result }, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+
+        }
+
+        /// <summary>
+        /// Parse to object
+        /// </summary>
+        /// <returns>Object</returns>
+        private static Expression<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>> ConvertToObject()
+        {
+            ParameterExpression jsonObjectParameter = Expression.Parameter(typeof(JsonDirectReader), "jsonDirectReader");
+            ParameterExpression jsonCustomConvertersParameter = Expression.Parameter(typeof(Dictionary<Type, IJsonCustomConverter>), "jsonCustomConverters");
+
+            var curType = _type;
+
+            List<Expression> expres = new List<Expression>();
+            List<ParameterExpression> variables = new List<ParameterExpression>();
+            List<MemberBinding> bindings = new List<MemberBinding>();
+            List<Expression> loopBody = new List<Expression>();
+
+            var result = Expression.Variable(curType, "result");
+            var enumerator = Expression.Variable(typeof(IEnumerator<KeyValuePair<JsonPropertyName, JsonDirectReader>>), "enumerator");
+            var kvp = Expression.Variable(typeof(KeyValuePair<JsonPropertyName, JsonDirectReader>), "kvp");
+            variables.Add(result);
+            variables.Add(enumerator);
+            variables.Add(kvp);
+            
+
+            var returnLabel = Expression.Label(typeof(T), "returnLabel");
+            var loopBreak = Expression.Label("loopBreak");
+
+            //Determine if the JSON object is null; value types cannot be null
+            if (curType.IsValueType)
+            {
+               expres.Add(Expression.IfThen(Expression.Equal(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Null)),
+               Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+               Expression.Property(jsonObjectParameter, "Position"), Expression.Constant(JsonType.Null), Expression.Constant(curType), Expression.Constant("反序列化失败，无法将json的null类型转换成值类型")))));
+            }
+            else
+            {
+                expres.Add(Expression.IfThen(Expression.Equal(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Null)),
+                Expression.Block(new Expression[]{Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), Expression.Return(returnLabel, Expression.Default(curType))})));
+            }
+            //Check if the type if assignable to JsonObject
+            if (curType.IsAssignableFrom(typeof(JsonObject)))
+            {
+                expres.Add(Expression.Return(returnLabel, Expression.Call(jsonObjectParameter, "ReadAsJsonObject", EmptyArray<Type>.Value)));
+                expres.Add(Expression.Label(returnLabel, result));
+                return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+            }
+            else if (typeof(JsonObject).IsAssignableFrom(curType))
+            {
+                var jsonObj = Expression.Variable(typeof(JsonObject), "jsonObj");
+                variables.Add(jsonObj);
+                expres.Add(Expression.Assign(jsonObj, Expression.Call(jsonObjectParameter, "ReadAsJsonObject", EmptyArray<Type>.Value)));
+                if(typeof(JsonArray).IsAssignableFrom(curType))
+                {
+                    expres.Add(Expression.IfThenElse(Expression.Equal(Expression.Property(jsonObj, "Type"), Expression.Constant(JsonType.Array)),
+                    Expression.Return(returnLabel, Expression.Convert(jsonObj, curType)),
+                    Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                        Expression.Property(jsonObj, "Position"), Expression.Property(jsonObj, "Type"), Expression.Constant(curType), Expression.Constant("反序列化失败，无法进行显式的JsonObject类型转换"))
+                    )));
+                    expres.Add(Expression.Label(returnLabel, result));
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+                }
+                else if(typeof(JsonBoolean).IsAssignableFrom(curType))
+                {
+                    expres.Add(Expression.IfThenElse(Expression.Equal(Expression.Property(jsonObj, "Type"), Expression.Constant(JsonType.Boolean)),
+                    Expression.Return(returnLabel, Expression.Convert(jsonObj, curType)),
+                    Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                        Expression.Property(jsonObj, "Position"), Expression.Property(jsonObj, "Type"), Expression.Constant(curType), Expression.Constant("反序列化失败，无法进行显式的JsonObject类型转换"))
+                    )));
+                    expres.Add(Expression.Label(returnLabel, result));
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+                }
+                else if(typeof(JsonContent).IsAssignableFrom(curType))
+                {
+                    expres.Add(Expression.IfThenElse(Expression.Equal(Expression.Property(jsonObj, "Type"), Expression.Constant(JsonType.Content)),
+                    Expression.Return(returnLabel, Expression.Convert(jsonObj, curType)),
+                    Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                        Expression.Property(jsonObj, "Position"), Expression.Property(jsonObj, "Type"), Expression.Constant(curType), Expression.Constant("反序列化失败，无法进行显式的JsonObject类型转换"))
+                    )));
+                    expres.Add(Expression.Label(returnLabel, result));
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+                }
+                else if(typeof(JsonNull).IsAssignableFrom(curType))
+                {
+                    expres.Add(Expression.IfThenElse(Expression.Equal(Expression.Property(jsonObj, "Type"), Expression.Constant(JsonType.Null)),
+                    Expression.Return(returnLabel, Expression.Convert(jsonObj, curType)),
+                    Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                        Expression.Property(jsonObj, "Position"), Expression.Property(jsonObj, "Type"), Expression.Constant(curType), Expression.Constant("反序列化失败，无法进行显式的JsonObject类型转换"))
+                    )));
+                    expres.Add(Expression.Label(returnLabel, result));
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+                }
+                else if(typeof(JsonNumber).IsAssignableFrom(curType))
+                {
+                    expres.Add(Expression.IfThenElse(Expression.Equal(Expression.Property(jsonObj, "Type"), Expression.Constant(JsonType.Number)),
+                    Expression.Return(returnLabel, Expression.Convert(jsonObj, curType)),
+                    Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                        Expression.Property(jsonObj, "Position"), Expression.Property(jsonObj, "Type"), Expression.Constant(curType), Expression.Constant("反序列化失败，无法进行显式的JsonObject类型转换"))
+                    )));
+                    expres.Add(Expression.Label(returnLabel, result));
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+                }
+                else if(typeof(JsonString).IsAssignableFrom(curType))
+                {
+                    expres.Add(Expression.IfThenElse(Expression.Equal(Expression.Property(jsonObj, "Type"), Expression.Constant(JsonType.String)),
+                    Expression.Return(returnLabel, Expression.Convert(jsonObj, curType)),
+                    Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                        Expression.Property(jsonObj, "Position"), Expression.Property(jsonObj, "Type"), Expression.Constant(curType), Expression.Constant("反序列化失败，无法进行显式的JsonObject类型转换"))
+                    )));
+                    expres.Add(Expression.Label(returnLabel, result));
+                    return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+                }
+            }
+            //Check if the type is an interface or abstract type
+            if (curType.IsInterface || curType.IsAbstract)
+            {
+                expres.Add(Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                Expression.Constant(0), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("类型为接口或者是抽象接口，无法创建该类型对象"))));
+                expres.Add(Expression.Label(returnLabel, Expression.Default(curType)));
+                return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+            }
+            //Check if the type has a default constructor
+            if (curType.GetConstructor(EmptyArray<Type>.Value) == null)
+            {
+                expres.Add(Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                Expression.Constant(0), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("反序列化类型没有默认的构造函数，无法创建该类型对象"))));
+                expres.Add(Expression.Label(returnLabel, Expression.Default(curType)));
+                return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+            }
+
+            //Type check: must be Content
+            expres.Add(Expression.IfThen(
+                Expression.NotEqual(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Content)),
+                Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType), typeof(Type), typeof(string) }),
+                Expression.Property(jsonObjectParameter, "Position"), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType),
+                Expression.Constant("Json对象不为Content类型不能解析成Object类型")))));
+
+            //Get writable properties and create variables for each
+            var properties = curType.GetProperties().Where(n => n.CanWrite).ToList();
+            var propVarMap = new Dictionary<System.Reflection.PropertyInfo, ParameterExpression>();
+            List<SwitchCase> switchCases = new List<SwitchCase>();
+            foreach (var item in properties)
+            {
+                //Check if deserialization should be ignored
+                var jsonIgnored = Attribute.GetCustomAttribute(item, typeof(JsonIgnoredAttribute)) as JsonIgnoredAttribute;
+                if (jsonIgnored != null && (jsonIgnored.JsonIgnoredMethod & JsonMethods.Deserialize) == JsonMethods.Deserialize)
+                {
+                    continue;
+                }
+
+                var propertyValue = Expression.Variable(item.PropertyType, item.Name + "propertyValue");
+                variables.Add(propertyValue);
+                propVarMap[item] = propertyValue;
+                bindings.Add(Expression.Bind(item, propertyValue));
+
+                #region Custom property name handling
+                JsonClass.Internal.StringView jsonPropertyNameStringView = new JsonClass.Internal.StringView(JsonUtility.GetPropertyName(item));
+                var jsonPropertyName = new JsonPropertyName(jsonPropertyNameStringView, jsonPropertyNameStringView.GetHashCode());
+                #endregion
+
+                
+
+                var opEquality = typeof(JsonPropertyName).GetMethod("op_Equality");
+                var deserializerMethod = typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(item.PropertyType)
+                    .GetMethod("Deserialzer", new Type[] { typeof(JsonDirectReader), typeof(Dictionary<Type, IJsonCustomConverter>) });
+
+                switchCases.Add(Expression.SwitchCase(Expression.Assign(propertyValue, Expression.Call(deserializerMethod, Expression.Property(kvp, "Value"), jsonCustomConvertersParameter)),
+                Expression.Constant(jsonPropertyName.HashCode)));
+                
+                
+                // // if (kvp.Key == jsonPropertyName) propertyValue = Deserialzer(kvp.Value, customConverters)
+                // loopBody.Add(Expression.IfThen(
+                //     Expression.Call(opEquality, Expression.Property(kvp, "Key"), Expression.Constant(jsonPropertyName)),
+                //     Expression.Assign(propertyValue, Expression.Call(deserializerMethod, Expression.Property(kvp, "Value"), jsonCustomConvertersParameter))));
+            }
+            try
+            {
+                //Expression.Switch(typeof(void), Expression.Constant("SwitchValue"), null, null, cases);
+                loopBody.Add(Expression.Switch(typeof(void), Expression.Call(Expression.Property(kvp, "Key"), "GetHashCode", EmptyArray<Type>.Value), Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), null, switchCases.ToArray()));
+            }
+            catch (Exception ex)
+            {
+
+            }
+            // enumerator = reader.ReadContent().GetEnumerator()
+            expres.Add(Expression.Assign(enumerator,
+                Expression.Call(
+                    Expression.Call(jsonObjectParameter, typeof(JsonDirectReader).GetMethod("ReadContent")),
+                    typeof(IEnumerable<KeyValuePair<JsonPropertyName, JsonDirectReader>>).GetMethod("GetEnumerator"))));
+
+            // Loop: while (enumerator.MoveNext()) { kvp = enumerator.Current; ... }
+            loopBody.Insert(0, Expression.IfThen(
+                Expression.IsFalse(Expression.Call(enumerator, typeof(IEnumerator).GetMethod("MoveNext"))),
+                Expression.Break(loopBreak)));
+            loopBody.Insert(1, Expression.Assign(kvp, Expression.Property(enumerator, "Current")));
+
+            expres.Add(Expression.Loop(Expression.Block(loopBody), loopBreak));
+
+            // result = new T { Prop1 = propVar1, ... }
+            expres.Add(Expression.Assign(result, Expression.MemberInit(Expression.New(curType), bindings)));
+            expres.Add(Expression.Label(returnLabel, result));
+
+            return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(variables, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+        }
+
+        private static Expression<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>> ConvertToNullable()
+        {
+            ParameterExpression jsonObjectParameter = Expression.Parameter(typeof(JsonDirectReader), "jsonDirectReader");
+            ParameterExpression jsonCustomConvertersParameter = Expression.Parameter(typeof(Dictionary<Type, IJsonCustomConverter>), "jsonCustomConverters");
+            var curType = _type;
+
+            List<Expression> expres = new List<Expression>();
+
+            var result = Expression.Variable(curType, "result");
+            var returnLabel = Expression.Label("returnLable");
+
+            //Get the generic type
+            var genericType = curType.GetGenericArguments().FirstOrDefault();
+            if (genericType == null)
+            {
+                return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Throw(Expression.New(typeof(JsonDirectDeserializationException).GetConstructor(new Type[] { typeof(int), typeof(JsonType),
+                    typeof(Type), typeof(string) }), Expression.Constant(0), Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(curType), Expression.Constant("反序列化出错获取，获取Nullable泛型出错！"))), jsonObjectParameter, jsonCustomConvertersParameter);
+            }
+            //Determine if the JSON object is null
+            expres.Add(Expression.IfThen(Expression.Equal(Expression.Property(jsonObjectParameter, "JsonType"), Expression.Constant(JsonType.Null)),
+                Expression.Block(new Expression[]{Expression.Call(jsonObjectParameter, "SkipCurrentObject", EmptyArray<Type>.Value), Expression.Return(returnLabel)})));
+            expres.Add(Expression.Assign(result, Expression.New(curType.GetConstructor(new Type[] { genericType }),
+                Expression.Call(typeof(JsonDirectDeserialzerExpression<>).MakeGenericType(genericType).GetMethod("Deserialzer", new Type[] { typeof(JsonDirectReader), typeof(Dictionary<Type, IJsonCustomConverter>) }), jsonObjectParameter, jsonCustomConvertersParameter))));
+
+            expres.Add(Expression.Label(returnLabel));
+            expres.Add(result);
+
+            return Expression.Lambda<Func<JsonDirectReader, Dictionary<Type, IJsonCustomConverter>, T>>(Expression.Block(new ParameterExpression[] { result }, expres), jsonObjectParameter, jsonCustomConvertersParameter);
+        }
+    }
+}

--- a/src/LHZ.FastJson/Json/JsonObjectType.cs
+++ b/src/LHZ.FastJson/Json/JsonObjectType.cs
@@ -12,29 +12,29 @@ namespace LHZ.FastJson.Json
     /// </summary>
     internal static class JsonObjectType
     {
-        private static readonly Dictionary<Type, ObjectType> _objectTypes = new Dictionary<Type, ObjectType>(Byte.MaxValue);
+        public static readonly Dictionary<Type, ObjectType> ObjectTypes = new Dictionary<Type, ObjectType>(Byte.MaxValue);
         static JsonObjectType()
         {
-            _objectTypes.Add(typeof(Boolean), ObjectType.Boolean);
-            _objectTypes.Add(typeof(Byte), ObjectType.Byte);
-            _objectTypes.Add(typeof(Char), ObjectType.Char);
-            _objectTypes.Add(typeof(Int16), ObjectType.Int16);
-            _objectTypes.Add(typeof(UInt16), ObjectType.UInt16);
-            _objectTypes.Add(typeof(Int32), ObjectType.Int32);
-            _objectTypes.Add(typeof(UInt32), ObjectType.UInt32);
-            _objectTypes.Add(typeof(Int64), ObjectType.Int64);
-            _objectTypes.Add(typeof(UInt64), ObjectType.UInt64);
-            _objectTypes.Add(typeof(Single), ObjectType.Float);
-            _objectTypes.Add(typeof(Double), ObjectType.Double);
-            _objectTypes.Add(typeof(Decimal), ObjectType.Decimal);
-            _objectTypes.Add(typeof(DateTime), ObjectType.DateTime);
-            _objectTypes.Add(typeof(String), ObjectType.String);
-            _objectTypes.Add(typeof(System.Enum), ObjectType.Enum);
-            _objectTypes.Add(typeof(IDictionary), ObjectType.Dictionary);
-            _objectTypes.Add(typeof(IEnumerable), ObjectType.Enumerable);
-            _objectTypes.Add(typeof(Object), ObjectType.Object);
-            _objectTypes.Add(typeof(IList), ObjectType.List);
-            _objectTypes.Add(typeof(Array), ObjectType.Array);
+            ObjectTypes.Add(typeof(Boolean), ObjectType.Boolean);
+            ObjectTypes.Add(typeof(Byte), ObjectType.Byte);
+            ObjectTypes.Add(typeof(Char), ObjectType.Char);
+            ObjectTypes.Add(typeof(Int16), ObjectType.Int16);
+            ObjectTypes.Add(typeof(UInt16), ObjectType.UInt16);
+            ObjectTypes.Add(typeof(Int32), ObjectType.Int32);
+            ObjectTypes.Add(typeof(UInt32), ObjectType.UInt32);
+            ObjectTypes.Add(typeof(Int64), ObjectType.Int64);
+            ObjectTypes.Add(typeof(UInt64), ObjectType.UInt64);
+            ObjectTypes.Add(typeof(Single), ObjectType.Float);
+            ObjectTypes.Add(typeof(Double), ObjectType.Double);
+            ObjectTypes.Add(typeof(Decimal), ObjectType.Decimal);
+            ObjectTypes.Add(typeof(DateTime), ObjectType.DateTime);
+            ObjectTypes.Add(typeof(String), ObjectType.String);
+            ObjectTypes.Add(typeof(System.Enum), ObjectType.Enum);
+            ObjectTypes.Add(typeof(IDictionary), ObjectType.Dictionary);
+            ObjectTypes.Add(typeof(IEnumerable), ObjectType.Enumerable);
+            ObjectTypes.Add(typeof(Object), ObjectType.Object);
+            ObjectTypes.Add(typeof(IList), ObjectType.List);
+            ObjectTypes.Add(typeof(Array), ObjectType.Array);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace LHZ.FastJson.Json
         /// </summary>
         internal static Dictionary<Type, ObjectType> GetObjectTypes()
         {
-            return _objectTypes;
+            return ObjectTypes;
         }
     }
 }

--- a/src/LHZ.FastJson/JsonClass/Internal/JsonString.cs
+++ b/src/LHZ.FastJson/JsonClass/Internal/JsonString.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 using LHZ.FastJson.Enum;
 using LHZ.FastJson.Exceptions;
@@ -63,11 +64,11 @@ namespace LHZ.FastJson.JsonClass.Internal
                                     for (int i = 0; i < 4; i++)
                                     {
                                         var uchar = _value.SourceString[valueIndex++];
-                                        if (!IsHexDigit(uchar))
+                                        if (!TryHexToInt(uchar, out int hexValue))
                                         {
                                             throw new JsonReadException((valueIndex - 1), "字符位置[" + (valueIndex - 1) + "]处，Json字符串解析错误，Unicode转义字符格式错误");
                                         }
-                                        value = (value << 4) + HexToInt(uchar);
+                                        value = (value << 4) + hexValue;
                                     }
                                     curChar = (char)value;
                                 }; break;
@@ -78,23 +79,34 @@ namespace LHZ.FastJson.JsonClass.Internal
                 return new String(chars);
             }
         }
-        private static bool IsHexDigit(char value)
-        {
-            return (value >= '0' && value <= '9') ||
-                   (value >= 'a' && value <= 'f') ||
-                   (value >= 'A' && value <= 'F');
-        }
-        private static int HexToInt(char value)
+        /// <summary>
+        /// Convert hexadecimal character to integer
+        /// </summary>
+        /// <param name="value">Hexadecimal character to convert</param>
+        /// <param name="result">Output integer value</param>
+        /// <returns>True if conversion is successful, false otherwise</returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public static bool TryHexToInt(char value, out int result)
         {
             if (value >= '0' && value <= '9')
             {
-                return value - '0';
+                result = value - '0';
+                return true;
             }
             if (value >= 'a' && value <= 'f')
             {
-                return value - 'a' + 10;
+                result = value - 'a' + 10;
+                return true;
             }
-            return value - 'A' + 10;
+            if (value >= 'A' && value <= 'F')
+            {
+                result = value - 'A' + 10;
+                return true;
+            }
+            result = 0;
+            return false;
         }
     }
 }

--- a/src/LHZ.FastJson/JsonClass/JsonPropertyName.cs
+++ b/src/LHZ.FastJson/JsonClass/JsonPropertyName.cs
@@ -23,19 +23,18 @@ namespace LHZ.FastJson.JsonClass
         public JsonPropertyName(string name)
         {
             Name = new StringView(name);
-            HashCode = 0;
+            HashCode = Name.GetHashCode();
         }
         internal JsonPropertyName(StringView stringView)
         {
             Name = stringView;
-            HashCode = 0;
+            HashCode = Name.GetHashCode();
         }
         internal JsonPropertyName(StringView stringView, int hashCode)
         {
             Name = stringView;
             HashCode = hashCode;
         }
-
         /// <summary>
         /// Equality operator
         /// </summary>
@@ -62,10 +61,6 @@ namespace LHZ.FastJson.JsonClass
         /// </summary>
         public override int GetHashCode()
         {
-            if(HashCode == 0)
-            {
-                HashCode = Name.GetHashCode();
-            }
             return HashCode;
         }
         /// <summary>

--- a/src/LHZ.FastJson/JsonClass/JsonString.cs
+++ b/src/LHZ.FastJson/JsonClass/JsonString.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 using LHZ.FastJson.Enum;
@@ -44,7 +45,7 @@ namespace LHZ.FastJson.JsonClass
             {
                 if (item == '"' || item == '\\' || item < 0x20)
                 {
-                    stringBuilder.Append(CharParaphrase(item));
+                    stringBuilder.Append(JsonString.CharParaphrase(item));
                 }
                 else
                 {
@@ -59,7 +60,7 @@ namespace LHZ.FastJson.JsonClass
         /// </summary>
         /// <param name="paraphrase">Character to escape</param>
         /// <returns>Escaped string</returns>
-        private string CharParaphrase(char paraphrase)
+        private static string CharParaphrase(char paraphrase)
         {
             if (paraphrase == '"')
                 return "\\\"";
@@ -76,7 +77,7 @@ namespace LHZ.FastJson.JsonClass
             else if (paraphrase == '\r')
                 return "\\r";
             else if (paraphrase < 0x20)
-                return "\\u" + ((int)paraphrase).ToString("x4");
+                return "\\u" + ((int)paraphrase).ToString("x4", CultureInfo.CurrentCulture);
             return paraphrase.ToString();
         }
         /// <summary>

--- a/src/LHZ.FastJson/JsonDirectReader.cs
+++ b/src/LHZ.FastJson/JsonDirectReader.cs
@@ -16,7 +16,7 @@ namespace LHZ.FastJson
         /// Initializes a new instance of the StringReader class with the specified string.
         /// </summary>
         /// <param name="content">The string to read.</param>
-        public JsonDirectReader(string content)
+        internal JsonDirectReader(string content)
         {
             Content = content ?? throw new ArgumentNullException(nameof(content));
             Position = 0;

--- a/src/LHZ.FastJson/JsonDirectReader.cs
+++ b/src/LHZ.FastJson/JsonDirectReader.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+using LHZ.FastJson.Enum;
+using LHZ.FastJson.Exceptions;
+using LHZ.FastJson.JsonClass;
+using LHZ.FastJson.JsonClass.Internal;
+using System.Runtime.CompilerServices;
+
+namespace LHZ.FastJson
+{
+    internal class JsonDirectReader
+    {
+        /// <summary>
+        /// Initializes a new instance of the StringReader class with the specified string.
+        /// </summary>
+        /// <param name="content">The string to read.</param>
+        public JsonDirectReader(string content)
+        {
+            Content = content ?? throw new ArgumentNullException(nameof(content));
+            Position = 0;
+            Length = content.Length;
+        }
+        /// <summary>
+        /// Gets the content of the string being read.
+        /// </summary>
+        public string Content { get; private set; }
+        /// <summary>
+        /// Gets the current position in the string being read.
+        /// </summary>
+        public int Position { get; private set; }
+        /// <summary>
+        /// Gets the length of the string being read.
+        /// </summary>
+        public int Length { get; private set; }
+        public bool IsReadEnd => Position >= Length;
+        public JsonType JsonType
+        {
+            get
+            {
+                SkipWhitespace();
+                var currentChar = Content[Position];
+                switch (currentChar)
+                {
+                    case '{': return JsonType.Content;
+                    case '"': return JsonType.String;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                    case '-':
+                    case '+': return JsonType.Number;
+                    case 'n': return JsonType.Null;
+                    case '[': return JsonType.Array;
+                    case 't':
+                    case 'f': return JsonType.Boolean;
+                    default: throw new JsonReadException(Position, "字符位置[" + Position + "]处，解析错误，未知Json类型");
+                }
+            }
+        }
+        /// <summary>
+        /// Reads the next character from the string and advances the position by one character.
+        /// </summary>
+        /// <returns>The next character in the string.</returns>
+        /// <exception cref="InvalidOperationException"></exception>
+#if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public char Read()
+        {
+            return Content[Position++];
+        }
+        /// <summary>
+        /// inscrease the specified number of characters in the string and advances the position accordingly.
+        /// </summary>
+        /// <param name="count">The number of characters to inscrease.</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        private void MoveNext(int count)
+        {
+            if (Position + count > Length)
+            {
+                throw new InvalidOperationException("End of string reached.");
+            }
+            Position += count;
+        }
+        /// <summary>
+        /// Gets the current character in the string without advancing the position.
+        /// </summary>
+        public char CurrentChar => Content[Position]; 
+        /// <summary>
+        /// Skips whitespace characters in the string and advances the position accordingly.
+        /// </summary>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public void SkipWhitespace()
+        {
+            if(Position >= Length)
+                return;
+            var curChar = Content[Position];
+            while (Position < (Length - 1) && (curChar == ' ' || curChar == '\r' || curChar == '\n' || curChar == '\t'))
+            {
+                curChar = Content[++Position];
+            }
+        }
+        /// <summary>
+        /// Reads a JSON property name from the string and returns it as a JsonPropertyName object.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="JsonReadException"></exception>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public JsonPropertyName ReadJsonPropertyName()
+        {
+            if (CurrentChar != '"')
+            {
+                int index = Position;
+                throw new JsonReadException(index, "字符位置[" + index + "]处，Json字符串解析属性名错误");
+            }
+            Position++;
+            int startPosition = Position;
+            uint hash = 5381;
+            while (true)
+            {
+                var curChar = Content[Position];
+                if (Position >= Length)
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，字符串未闭合");
+                }
+                if (curChar < 0x20)
+                {
+                    int curIndex = Position;
+                    throw new JsonReadException(curIndex, "字符位置[" + curIndex + "]处，Json字符串解析错误，字符串中存在未转义控制字符");
+                }
+                if (curChar == '"')
+                {
+                    int length = (int)(Position - startPosition);
+                    if (length < 0)
+                    {
+                        throw new JsonReadException(startPosition, "字符位置[" + startPosition + "]处，Json字符串解析错误，属性名不能为空");
+                    }
+                    Position++;
+                    SkipWhitespace();
+                    if(Content[Position] != ':')
+                    {
+                        throw new JsonReadException(Position, "字符位置[" + Position + "]处，期望出现':'但是出现了意外字符'"+Content[Position]+"'");
+                    }
+                    MoveNext(1);
+                    return new JsonPropertyName(new StringView(Content, startPosition, length), (int)hash);
+                }
+                hash = (hash << 5) + hash + curChar;
+                Position++;
+            }
+        }
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public IEnumerable<KeyValuePair<JsonPropertyName, JsonDirectReader>> ReadContent()
+        {
+            while(true)
+            {
+                SkipWhitespace();
+                switch(Content[Position])
+                {
+                    case '{' : MoveNext(1); continue;
+                    case ',' : MoveNext(1); break;
+                    case '}' : MoveNext(1); SkipWhitespace(); yield break;
+                }
+                SkipWhitespace();
+                var propertyName = ReadJsonPropertyName();
+                SkipWhitespace();
+                yield return new KeyValuePair<JsonPropertyName, JsonDirectReader>(propertyName, this);
+            }
+        }
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public IEnumerable<JsonDirectReader> ReadArray()
+        {
+            while(true)
+            {
+                SkipWhitespace();
+                switch(Content[Position])
+                {
+                    case '[' : MoveNext(1); continue;
+                    case ',' : MoveNext(1); break;
+                    case ']' : MoveNext(1); SkipWhitespace(); yield break;
+                }
+                SkipWhitespace();
+                yield return this;
+            }
+        }
+        /// <summary>
+        /// Read as String
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="JsonReadException"></exception>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public string ReadString()
+        {
+            if (CurrentChar != '"')
+            {
+                throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析string错误");
+            }
+            MoveNext(1);
+            var startPosition = Position;
+            StringBuilder stringBuilder = null;
+            while (true)
+            {
+                if (Position >= Length)
+                {
+                    int curIndex = Position;
+                    throw new JsonReadException(curIndex, "字符位置[" + curIndex + "]处，Json字符串解析错误，字符串未闭合");
+                }
+                char current = Content[Position];
+                if (current == '"')
+                {
+                    if(stringBuilder == null)
+                    {
+                        var str = Content.Substring(startPosition, (int)(Position - startPosition));
+                        MoveNext(1);
+                        return str;
+                    }
+                    stringBuilder.Append(Content, startPosition, (int)(Position - startPosition));
+                    MoveNext(1);
+                    return stringBuilder.ToString();
+                }
+
+                if (current < 0x20)
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，字符串中存在未转义控制字符");
+                }
+                if (current == '\\')
+                {
+                    if(stringBuilder == null)
+                    {
+                        stringBuilder = new StringBuilder();
+                    }
+                    stringBuilder.Append(Content, startPosition, (int)(Position - startPosition));
+                    MoveNext(1);
+                    current = Content[Position];
+                    switch (current)
+                    {
+                            case '"': stringBuilder.Append('\"'); break;
+                            case '\\': stringBuilder.Append('\\'); break;
+                            case '/': stringBuilder.Append('/'); break;
+                            case 'b': stringBuilder.Append('\b'); break;
+                            case 'f': stringBuilder.Append('\f'); break;
+                            case 'n': stringBuilder.Append('\n'); break;
+                            case 'r': stringBuilder.Append('\r'); break;
+                            case 't': stringBuilder.Append('\t'); break;
+                            case 'u': 
+                                {
+                                    int value = 0;
+                                    for (int i = 0; i < 4; i++)
+                                    {
+                                        MoveNext(1);
+                                        if(JsonClass.Internal.JsonString.TryHexToInt(Content[Position], out int hexValue))
+                                        {
+                                            value = (value << 4) + hexValue;
+                                        }
+                                        else
+                                        {
+                                            throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，Unicode转义字符格式错误");
+                                        }
+                                    }
+                                    stringBuilder.Append((char)value);
+                                }; break;
+                        default:
+                            throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，'\\" + current + "'转义失败");
+                    }
+                    MoveNext(1);
+                    startPosition = Position;
+                    continue;
+                }
+                MoveNext(1);
+            }
+        }
+        /// <summary>
+        /// Read JSON Number object
+        /// </summary>
+        /// <returns>StringView object</returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        internal StringView ReadNumber()
+        {
+            int startPosition = Position;
+            if (Content[Position] == '-')
+            {
+                MoveNext(1);
+                if (Position >= Length || !JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，负号后缺少数字，解析number出错");
+                }
+            }
+            if (Content[Position] == '0')
+            {
+                MoveNext(1);
+                if (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，number不能包含前导零");
+                }
+            }
+            else if (JsonReader.IsOneToNine(Content[Position]))
+            {
+                while (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    MoveNext(1);
+                }
+            }
+            else
+            {
+                throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，解析number出错");
+            }
+            if (Position < Length && Content[Position] == '.')
+            {
+                MoveNext(1);
+                if (Position >= Length || !JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，小数点后缺少数字，解析number出错");
+                }
+                while (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    MoveNext(1);
+                }
+            }
+
+            if (Position < Length && (Content[Position] == 'e' || Content[Position] == 'E'))
+            {
+                MoveNext(1);
+                if (Position < Length && (Content[Position] == '+' || Content[Position] == '-'))
+                {
+                    MoveNext(1);
+                }
+                if (Position >= Length || !JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，指数后缺少数字，解析number出错");
+                }
+                while (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    MoveNext(1);
+                }
+            }
+            return new  JsonClass.Internal.StringView(Content, startPosition, (int)(Position - startPosition));
+        }
+         /// <summary>
+        /// Parse JSON Boolean object
+        /// </summary>
+        /// <returns>JSON object</returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        internal bool ReadBoolean()
+        {
+            int startPosition = Position;
+            if (Content[startPosition] == 't')
+            {
+                MoveNext(4);
+                if (Content[startPosition + 1] == 'r' && Content[startPosition + 2] == 'u' && Content[startPosition + 3] == 'e')
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                MoveNext(5);
+                if (Content[startPosition + 1] == 'a' && Content[startPosition + 2] == 'l' && Content[startPosition + 3] == 's' && Content[startPosition + 4] == 'e')
+                {
+                    return false;
+                }
+            }
+            throw new JsonReadException(startPosition, "字符位置[" + startPosition + "]处，Json字符串解析boolean错误");
+        }
+        /// <summary>
+        /// Parse JSON Null
+        /// </summary>
+        /// <returns>JSON object</returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        internal T ReadNull<T>() where T : class
+        {
+            MoveNext(4);
+            if (Content[Position - 3] == 'u' && Content[Position - 2] == 'l' && Content[Position - 1] == 'l')
+            {
+                return null;
+            }
+            throw new JsonReadException(Position - 4, "字符位置[" + (Position - 4) + "]处，Json字符串解析null错误");
+        }
+        /// <summary>
+        /// Skip current json object
+        /// </summary>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        internal void SkipCurrentObject()
+        {
+            switch (Content[Position])
+            {
+                case '{':
+                    {
+                        foreach (var item in ReadContent())
+                        {
+                            item.Value.SkipCurrentObject();
+                        }
+                        break;
+                    }
+                case '"': ReadString(); break;
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                case '-':
+                case '+': ReadNumber(); break;
+                case 'n': ReadNull<object>(); break;
+                case '[':
+                    {
+                        foreach (var item in ReadContent())
+                        {
+                            item.Value.SkipCurrentObject();
+                        }
+                        break;
+                    }
+                case 't':
+                case 'f': ReadBoolean(); break;
+                default: throw new JsonReadException(Position, "字符位置[" + Position + "]处，解析错误，未知Json类型");
+            }
+        }
+#if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public JsonObject ReadAsJsonObject()
+        {
+            var reader = new JsonReader(Content, Position);
+            var obj = reader.JsonRead();
+            Position = reader.EndPosition;
+            return obj;
+        }
+    }
+}

--- a/src/LHZ.FastJson/JsonReader.cs
+++ b/src/LHZ.FastJson/JsonReader.cs
@@ -19,9 +19,12 @@ namespace LHZ.FastJson
         private char* _startPoint;
         private char* _curPoint;
         private char* _endPoint;
-
+        private int _startPosition;
         private JsonClass.JsonObject _jsonObject;
-
+        /// <summary>
+        /// end read position
+        /// </summary>
+        internal int EndPosition => _jsonObject == null ? -1 : (int)(_curPoint - _startPoint);
         /// <summary>
         /// Determine if it is a JSON string
         /// </summary>
@@ -73,6 +76,24 @@ namespace LHZ.FastJson
             _jsonString = jsonString;
         }
         /// <summary>
+        /// Initialize JsonReader
+        /// </summary>
+        /// <param name="jsonString">JSON string</param>
+        /// <param name="startPosition">start read position</param>
+        public JsonReader(string jsonString, int startPosition)
+        {
+            _jsonString = jsonString;
+            if(_jsonString.Length <= startPosition)
+            {
+                throw new ArgumentException("startPosition must be smaller than jsonstring length!");
+            }
+            else if(startPosition < 0)
+            {
+                throw new ArgumentException("startPosition must be >= 0");
+            }
+            _startPosition = startPosition;
+        }
+        /// <summary>
         /// Parse string
         /// </summary>
         /// <returns>JSON object</returns>
@@ -82,7 +103,6 @@ namespace LHZ.FastJson
             {
                 return _jsonObject;
             }
-
             if (string.IsNullOrEmpty(_jsonString))
             {
                 throw new ArgumentNullException("Json解析错误，字符串为空");
@@ -91,11 +111,11 @@ namespace LHZ.FastJson
             {
                 _startPoint = point;
                 _endPoint = point + _jsonString.Length;
-                _curPoint = point;
+                _curPoint = point + _startPosition;
 
                 var jsonObject = GetJsonObject();
                 SkipWhitespace();
-                if (_curPoint != _endPoint)
+                if (_curPoint != _endPoint && _startPosition ==0)
                 {
                     int index = (int)(_curPoint - _startPoint);
                     throw new JsonReadException(index, "字符位置[" + index + "]处，Json字符串已解析完成但仍存在多余字符");
@@ -282,17 +302,30 @@ namespace LHZ.FastJson
                 MoveNext(1);
             }
         }
-        private static bool IsDigit(char value)
+        /// <summary>
+        /// Check if it's a number
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public static bool IsDigit(char value)
         {
             return value >= '0' && value <= '9';
         }
-
-        private static bool IsOneToNine(char value)
+        /// <summary>
+        /// Check if it's 1 to 9
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public static bool IsOneToNine(char value)
         {
             return value >= '1' && value <= '9';
         }
-
-
         /// <summary>
         /// Parse JSON Number object
         /// </summary>

--- a/src/LHZ.FastJson/Utils/StringReader.cs
+++ b/src/LHZ.FastJson/Utils/StringReader.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Mime;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+using LHZ.FastJson.Enum;
+using LHZ.FastJson.Exceptions;
+using LHZ.FastJson.JsonClass;
+using LHZ.FastJson.JsonClass.Internal;
+
+namespace LHZ.FastJson.Utils
+{
+    /// <summary>
+    /// String reader utility class
+    /// </summary>
+    public struct StringReader
+    {
+        /// <summary>
+        /// Initializes a new instance of the StringReader class with the specified string.
+        /// </summary>
+        /// <param name="content">The string to read.</param>
+        public StringReader(string content)
+        {
+            Content = content ?? throw new ArgumentNullException(nameof(content));
+            Position = 0;
+            Length = content.Length;
+            JsonType = JsonType.Null;
+        }
+        /// <summary>
+        /// Gets the content of the string being read.
+        /// </summary>
+        public string Content { get; private set; }
+        /// <summary>
+        /// Gets the current position in the string being read.
+        /// </summary>
+        public int Position { get; private set; }
+        /// <summary>
+        /// Gets the length of the string being read.
+        /// </summary>
+        public int Length { get; private set; }
+        public JsonType JsonType {get; private set;}
+        /// <summary>
+        /// Reads the next character from the string and advances the position by one character.
+        /// </summary>
+        /// <returns>The next character in the string.</returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public char Read()
+        {
+            return Content[Position++];
+        }
+        /// <summary>
+        /// inscrease the specified number of characters in the string and advances the position accordingly.
+        /// </summary>
+        /// <param name="count">The number of characters to inscrease.</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        private void MoveNext(int count)
+        {
+            if (Position + count > Length)
+            {
+                throw new InvalidOperationException("End of string reached.");
+            }
+            Position += count;
+        }
+        /// <summary>
+        /// Gets the current character in the string without advancing the position.
+        /// </summary>
+        public char CurrentChar => Content[Position]; 
+        /// <summary>
+        /// Skips whitespace characters in the string and advances the position accordingly.
+        /// </summary>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        public void SkipWhitespace()
+        {
+            if(Position >= Length)
+                return;
+            var curChar = Content[Position];
+            while (Position < Length && (curChar == ' ' || curChar == '\r' || curChar == '\n' || curChar == '\t'))
+            {
+                curChar = Content[Position++];
+            }
+        }
+        /// <summary>
+        /// Reads a JSON property name from the string and returns it as a JsonPropertyName object.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="JsonReadException"></exception>
+        public JsonPropertyName ReadJsonPropertyName()
+        {
+            if (CurrentChar != '"')
+            {
+                int index = Position;
+                throw new JsonReadException(index, "字符位置[" + index + "]处，Json字符串解析属性名错误");
+            }
+            Position++;
+            int startPosition = Position;
+            uint hash = 5381;
+            while (true)
+            {
+                var curChar = Content[Position];
+                if (Position >= Length)
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，字符串未闭合");
+                }
+                if (curChar < 0x20)
+                {
+                    int curIndex = Position;
+                    throw new JsonReadException(curIndex, "字符位置[" + curIndex + "]处，Json字符串解析错误，字符串中存在未转义控制字符");
+                }
+                if (curChar == '"')
+                {
+                    int length = (int)(Position - startPosition);
+                    if (length < 0)
+                    {
+                        throw new JsonReadException(startPosition, "字符位置[" + startPosition + "]处，Json字符串解析错误，属性名不能为空");
+                    }
+                    Position++;
+                    SkipWhitespace();
+                    if(Content[Position] != ':')
+                    {
+                        throw new JsonReadException(Position, "字符位置[" + Position + "]处，期望出现':'但是出现了意外字符'"+Content[Position]+"'");
+                    }
+                    return new JsonPropertyName(new StringView(Content, startPosition, length), (int)hash);
+                }
+                hash = (hash << 5) + hash + curChar;
+                Position++;
+            }
+        }
+        public IEnumerable<KeyValuePair<JsonPropertyName, StringReader>> ReadJsonContent()
+        {
+            while(Content[Position] != '}')
+            {
+                SkipWhitespace();
+                var propertyName = ReadJsonPropertyName();
+                yield return new KeyValuePair<JsonPropertyName, StringReader>(propertyName, this);
+            }
+        }
+        /// <summary>
+        /// Read as String
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="JsonReadException"></exception>
+        public string ReadString()
+        {
+            if (CurrentChar != '"')
+            {
+                throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析string错误");
+            }
+            Position++;
+            var startPosition = Position;
+            StringBuilder stringBuilder = null;
+            while (true)
+            {
+                if (Position >= Length)
+                {
+                    int curIndex = Position;
+                    throw new JsonReadException(curIndex, "字符位置[" + curIndex + "]处，Json字符串解析错误，字符串未闭合");
+                }
+                char current = Content[Position];
+                if (current == '"')
+                {
+                    if(stringBuilder == null)
+                    {
+                        var str = Content.Substring(startPosition, (int)(Position - startPosition));
+                        MoveNext(1);
+                        return str;
+                    }
+                    stringBuilder.Append(Content, startPosition, (int)(Position - startPosition));
+                    MoveNext(1);
+                    return stringBuilder.ToString();
+                }
+
+                if (current < 0x20)
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，字符串中存在未转义控制字符");
+                }
+                if (current == '\\')
+                {
+                    if(stringBuilder == null)
+                    {
+                        stringBuilder = new StringBuilder();
+                    }
+                    stringBuilder.Append(Content, startPosition, (int)(Position - startPosition));
+                    MoveNext(1);
+                    current = Content[Position];
+                    switch (current)
+                    {
+                            case '"': stringBuilder.Append('\"'); break;
+                            case '\\': stringBuilder.Append('\\'); break;
+                            case '/': stringBuilder.Append('/'); break;
+                            case 'b': stringBuilder.Append('\b'); break;
+                            case 'f': stringBuilder.Append('\f'); break;
+                            case 'n': stringBuilder.Append('\n'); break;
+                            case 'r': stringBuilder.Append('\r'); break;
+                            case 't': stringBuilder.Append('\t'); break;
+                            case 'u': 
+                                {
+                                    int value = 0;
+                                    for (int i = 0; i < 4; i++)
+                                    {
+                                        MoveNext(1);
+                                        if(JsonClass.Internal.JsonString.TryHexToInt(Content[Position], out int hexValue))
+                                        {
+                                            value = (value << 4) + hexValue;
+                                        }
+                                        else
+                                        {
+                                            throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，Unicode转义字符格式错误");
+                                        }
+                                    }
+                                    stringBuilder.Append((char)value);
+                                }; break;
+                        default:
+                            throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，'\\" + current + "'转义失败");
+                    }
+                    continue;
+                }
+                MoveNext(1);
+                startPosition = Position;
+            }
+        }
+        /// <summary>
+        /// Read JSON Number object
+        /// </summary>
+        /// <returns>StringView object</returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        private StringView ReadNumber()
+        {
+            int startPosition = Position;
+            if (Content[Position] == '-')
+            {
+                MoveNext(1);
+                if (Position >= Length || !JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，负号后缺少数字，解析number出错");
+                }
+            }
+            if (Content[Position] == '0')
+            {
+                MoveNext(1);
+                if (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，number不能包含前导零");
+                }
+            }
+            else if (JsonReader.IsOneToNine(Content[Position]))
+            {
+                while (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    MoveNext(1);
+                }
+            }
+            else
+            {
+                throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，解析number出错");
+            }
+            if (Position < Length && Content[Position] == '.')
+            {
+                MoveNext(1);
+                if (Position >= Length || !JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，小数点后缺少数字，解析number出错");
+                }
+                while (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    MoveNext(1);
+                }
+            }
+
+            if (Position < Length && (Content[Position] == 'e' || Content[Position] == 'E'))
+            {
+                MoveNext(1);
+                if (Position < Length && (Content[Position] == '+' || Content[Position] == '-'))
+                {
+                    MoveNext(1);
+                }
+                if (Position >= Length || !JsonReader.IsDigit(Content[Position]))
+                {
+                    throw new JsonReadException(Position, "字符位置[" + Position + "]处，Json字符串解析错误，指数后缺少数字，解析number出错");
+                }
+                while (Position < Length && JsonReader.IsDigit(Content[Position]))
+                {
+                    MoveNext(1);
+                }
+            }
+            return new  JsonClass.Internal.StringView(Content, startPosition, (int)(Position - startPosition));
+        }
+         /// <summary>
+        /// Parse JSON Boolean object
+        /// </summary>
+        /// <returns>JSON object</returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        private bool ReadBoolean()
+        {
+            int startPosition = Position;
+            if (Content[startPosition] == 't')
+            {
+                MoveNext(4);
+                if (Content[startPosition + 1] == 'r' && Content[startPosition + 2] == 'u' && Content[startPosition + 3] == 'e')
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                MoveNext(5);
+                if (Content[startPosition + 1] == 'a' && Content[startPosition + 2] == 'l' && Content[startPosition + 3] == 's' && Content[startPosition + 4] == 'e')
+                {
+                    return false;
+                }
+            }
+            throw new JsonReadException(startPosition, "字符位置[" + startPosition + "]处，Json字符串解析boolean错误");
+        }
+        /// <summary>
+        /// Parse JSON Null
+        /// </summary>
+        /// <returns>JSON object</returns>
+        #if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        #endif
+        private object ReadNull()
+        {
+            MoveNext(4);
+            if (Content[Position - 3] == 'u' && Content[Position - 2] == 'l' && Content[Position - 1] == 'l')
+            {
+                return null;
+            }
+            throw new JsonReadException(Position - 4, "字符位置[" + (Position - 4) + "]处，Json字符串解析null错误");
+        }
+        /// <summary>
+        /// Parse JSON object
+        /// </summary>
+        /// <returns>JSON object</returns>
+        private void InitType()
+        {
+            SkipWhitespace();
+            var currentChar = Content[Position];
+            switch(currentChar)
+            {
+                case '{': JsonType = JsonType.Content; break;
+                case '"': JsonType = JsonType.String; break;
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                case '-':
+                case '+': JsonType = JsonType.Number; break;
+                case 'n': JsonType = JsonType.Null; break;
+                case '[': JsonType = JsonType.Array; break;
+                case 't':
+                case 'f': JsonType = JsonType.Boolean; break;
+                default: throw new JsonReadException(Position, "字符位置[" + Position + "]处，解析错误，未知Json类型");
+            }
+        }
+    }
+}


### PR DESCRIPTION
feat: refactor deserialization to direct-stream reading with partial JSON support
    
Core changes:
- Add JsonDirectReader and JsonDirectDeserialzerExpression, refactoring
  deserialization from tree-based (IJsonObject) to direct-stream reading,
  reducing intermediate object allocations
- JsonReader now supports partial JSON parsing via startPosition parameter
- Add JsonDirectDeserializationException as a dedicated exception type
- Make JsonObjectType._objectTypes public as ObjectTypes property

Performance optimizations:
- Add AggressiveInlining to IsDigit, IsOneToNine, and TryHexToInt
- Merge IsHexDigit + HexToInt into a single TryHexToInt method

Bug fixes:
- Mark JsonString.CharParaphrase as static
- Specify CultureInfo.CurrentCulture in ToString("x4") to avoid locale issues

Tests & benchmarks:
- Change benchmark target framework to net461, add System.Text.Json baseline
- Add PartOfJsonRead test for partial JSON parsing
- Update exception type assertions to match new exception hierarchy